### PR TITLE
docs: Add version badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Claude Conductor for Claude Code
 
 [![CI](https://github.com/rbarcante/claude-conductor/actions/workflows/ci.yml/badge.svg)](https://github.com/rbarcante/claude-conductor/actions/workflows/ci.yml)
+[![Release](https://img.shields.io/github/v/release/rbarcante/claude-conductor)](https://github.com/rbarcante/claude-conductor/releases/latest)
 
 **Measure twice, code once.**
 


### PR DESCRIPTION
## Summary
- Add GitHub release version badge to README

## Preview
The badge displays the current release version (e.g., v1.0.1) and links to the latest release page.