### PR TITLE
fix(ci): use manifest mode for release-please to sync version across files

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "conductor",
-  "version": "0.1.1",
+  "version": "1.1.0",
   "description": "Context-driven development framework that enables structured lifecycle for software projects: Context → Spec & Plan → Implement",
   "author": {
     "name": "Ricardo Barcante",

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,9 +27,8 @@ jobs:
         uses: googleapis/release-please-action@v4
         id: release
         with:
-          # Use simple release type for non-package projects
-          release-type: simple
-          # Token for creating releases and PRs
+          # Use manifest mode: reads release-please-config.json and .release-please-manifest.json
+          # This ensures extra-files (plugin.json), changelog-sections, and other config are applied
           token: ${{ secrets.GITHUB_TOKEN }}
 
       # Optional: Output release information for downstream jobs


### PR DESCRIPTION
The release workflow was specifying `release-type: simple` inline, which
caused release-please-action v4 to bypass release-please-config.json.
This meant extra-files (plugin.json version sync), changelog-sections,
and other config settings were ignored. Remove the inline release-type
so the action runs in manifest mode, reading both release-please-config.json
and .release-please-manifest.json. Also sync plugin.json to current 1.1.0.

https://claude.ai/code/session_01PSiQsxe84A22R9xh7EQdAB