### PR TITLE
Fix release-please not bumping plugin.json version

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,6 +10,7 @@
     {
       "name": "conductor",
       "description": "Context-driven development framework that enables structured lifecycle for software projects: Context, Spec & Plan, Implement",
+      "version": "1.2.0",
       "source": "./"
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "conductor",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Context-driven development framework that enables structured lifecycle for software projects: Context → Spec & Plan → Implement",
   "author": {
     "name": "Ricardo Barcante",

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,9 +27,8 @@ jobs:
         uses: googleapis/release-please-action@v4
         id: release
         with:
-          # Use simple release type for non-package projects
-          release-type: simple
-          # Token for creating releases and PRs
+          config-file: release-please-config.json
+          manifest-file: .release-please-manifest.json
           token: ${{ secrets.GITHUB_TOKEN }}
 
       # Optional: Output release information for downstream jobs

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -28,6 +28,11 @@
           "type": "json",
           "path": ".claude-plugin/plugin.json",
           "jsonpath": "$.version"
+        },
+        {
+          "type": "json",
+          "path": ".claude-plugin/marketplace.json",
+          "jsonpath": "$.plugins[0].version"
         }
       ]
     }


### PR DESCRIPTION
## Summary
- Fix release workflow to use `config-file`/`manifest-file` instead of inline `release-type`, which caused `release-please-config.json` (and its `extra-files`) to be ignored entirely
- Sync `plugin.json` version to 1.2.0 (was stuck at 1.1.0)
- Add `version` field to `marketplace.json` and register it in `extra-files` for future bumps