### PR TITLE
feat: Remove conductor-specific git commits

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,9 +57,9 @@ Follow the [Conventional Commits](https://www.conventionalcommits.org/) format:
 - All other types → no version bump (may appear in changelog)
 
 > **Important:** Only the types listed above are recognized by Release Please. Using
-> non-standard types (e.g., `conductor(track):`) will cause commits to be **completely
-> ignored** for both changelog generation and version bumping. When committing feature
-> work, always use `feat(<scope>):` to ensure proper semantic versioning.
+> non-standard types will cause commits to be **completely ignored** for both changelog
+> generation and version bumping. Always use standard Conventional Commits types
+> (e.g., `feat(<scope>):`, `fix(<scope>):`) to ensure proper semantic versioning.
 
 Example:
 ```

--- a/TESTING.md
+++ b/TESTING.md
@@ -144,7 +144,8 @@ cat conductor/tracks.md
 - `plan.md` contains phased task list with TDD structure
 - `metadata.json` created with correct type
 - `conductor/tracks.md` updated with new track
-- Git commit created: `conductor(track): Create track 'Add user login feature'`
+- If user chose "Commit now": Git commit created with standard type (e.g., `chore: Create track 'Add user login feature'`)
+- If user chose "Defer to first task": Track files left uncommitted for bundling with first task commit
 
 **Validation:**
 ```bash
@@ -188,10 +189,9 @@ cat conductor/tracks/<track_id>/plan.md
 **Expected Results:**
 - Track status changes to `[~]` in tracks.md
 - Tasks marked `[~]` then `[x]` in plan.md
-- Code commits created for each task
-- Plan commits created for each task completion
-- Git notes attached to commits
-- Phase checkpoints created if phase completes
+- Code commits created for each task (with plan.md updates bundled in)
+- Git notes attached to commits (optional)
+- Phase completion verified but no separate checkpoint commits created
 
 **Validation:**
 ```bash
@@ -239,10 +239,10 @@ cat conductor/tracks/<track_id>/plan.md
 5. Should offer archive/delete/skip options
 
 **Expected Results:**
-- Track marked `[x]` in tracks.md
-- Sync commit created if docs updated
+- Track marked as completed in metadata.json
+- Documentation updates bundled with last code commit or left for user
 - Track archived/deleted/kept based on choice
-- Git history clean and logical
+- Git history clean — no conductor-specific commits
 
 ---
 

--- a/agents/git-history-analyst.md
+++ b/agents/git-history-analyst.md
@@ -111,22 +111,25 @@ Find all commits related to a track, phase, or task.
    # Find by track ID in commit messages
    git log --oneline --grep="track_id" --grep="Track: description"
 
-   # Find by conductor prefixes
-   git log --oneline --grep="conductor(track):" --grep="conductor(plan):" --grep="conductor(checkpoint):"
+   # Find commits that modified track files (plan.md, metadata.json, spec.md)
+   git log --oneline -- conductor/tracks/<track_id>/
 
-   # Find by task SHA references in plan.md
-   git log --oneline -- conductor/tracks/<track_id>/plan.md
+   # Find commits on the track's feature branch
+   git log --oneline <base_branch>..<track_branch>
+
+   # Find by reading plan.md for recorded commit SHAs
+   # Parse [abc1234] and [checkpoint: abc1234] annotations from plan.md
    ```
 
 3. **Classify Commits:**
 
-   | Pattern | Type |
-   |---------|------|
-   | `feat(`, `fix(`, `refactor(` | implementation |
-   | `conductor(plan):` | plan-update |
-   | `conductor(checkpoint):` | checkpoint |
-   | `conductor(track):` | track-creation |
-   | `conductor(setup):` | setup |
+   | Strategy | Type |
+   |----------|------|
+   | `feat(`, `fix(`, `refactor(`, `test(` in message | implementation |
+   | Modified `conductor/tracks/<id>/plan.md` | plan-related |
+   | SHA referenced in plan.md `[checkpoint: <sha>]` | phase-boundary |
+   | `chore: Create track` in message | track-creation |
+   | Modified `conductor/tracks/<id>/metadata.json` | track-management |
 
 4. **Build Commit List:**
    - Sort by date (newest first)
@@ -142,8 +145,7 @@ Build an ordered list of commits to revert for a given target.
 
 2. **Determine Revert Order:**
    - Commits must be reverted in reverse chronological order
-   - Plan update commits come before implementation commits
-   - Checkpoint commits come after phase implementation commits
+   - Since plan.md updates are bundled into code commits, each commit may contain both code and plan changes
 
 3. **Check for Conflicts:**
    - Identify commits that may have been amended or rebased
@@ -181,19 +183,38 @@ Analyze the commit history for patterns and insights.
    - Authors/contributors
    - Activity timeline
 
-## Commit Message Patterns
+## Commit Identification Strategies
 
-Conductor uses these commit message patterns:
+Conductor bundles plan.md updates into code commits (no separate conductor-specific commits). Use these strategies to identify track-related commits:
+
+### Strategy 1: File-Based Detection
+```bash
+# Find all commits that touched track files
+git log --oneline -- conductor/tracks/<track_id>/
+```
+
+### Strategy 2: Plan.md SHA References
+Parse `plan.md` for recorded commit SHAs:
+- Task SHAs: `- [x] Task: Description [abc1234]`
+- Phase checkpoints: `## Phase 1 [checkpoint: def5678]`
+
+### Strategy 3: Branch-Based Detection
+```bash
+# Find all commits on the track's feature branch
+git log --oneline <base_branch>..<track_branch>
+```
+
+### Strategy 4: Standard Commit Patterns
 
 | Pattern | Example | Identifies |
 |---------|---------|------------|
-| `conductor(track):` | `conductor(track): Create track 'Add auth'` | Track creation |
-| `conductor(plan):` | `conductor(plan): Mark task 'Setup DB' as complete` | Plan updates |
-| `conductor(checkpoint):` | `conductor(checkpoint): Checkpoint end of Phase 1` | Phase completion |
-| `conductor(setup):` | `conductor(setup): Add conductor setup files` | Project setup |
 | `feat(scope):` | `feat(auth): Add login endpoint` | Feature implementation |
 | `fix(scope):` | `fix(auth): Fix password validation` | Bug fixes |
 | `test(scope):` | `test(auth): Add login tests` | Test additions |
+| `chore: Create track` | `chore: Create track 'Add auth'` | Track creation |
+| `chore: Archive track` | `chore: Archive track 'Add auth'` | Track archival |
+
+**Note:** Legacy repositories may still have `conductor(track):`, `conductor(checkpoint):`, and `conductor(plan):` prefixes. The agent should recognize these for backwards compatibility.
 
 ## Git Log Formatting
 
@@ -224,29 +245,28 @@ Your entire response MUST be valid JSON. Do not include any text before or after
       {
         "sha": "abc1234567890def",
         "short_sha": "abc1234",
-        "message": "conductor(checkpoint): Checkpoint end of Phase 1",
+        "message": "feat(auth): Add login endpoint",
         "author": "dev@example.com",
         "date": "2026-01-15T15:30:00Z",
-        "type": "checkpoint",
-        "related_to": "Phase 1"
+        "type": "implementation",
+        "related_to": "Task: Implement login (Phase 1 final task)"
       },
       {
         "sha": "def5678901234abc",
         "short_sha": "def5678",
-        "message": "feat(auth): Add login endpoint",
+        "message": "feat(auth): Add user registration",
         "author": "dev@example.com",
         "date": "2026-01-15T14:00:00Z",
         "type": "implementation",
-        "related_to": "Task: Implement login"
+        "related_to": "Task: Add user registration"
       }
     ],
     "revert_order": null,
     "warnings": [],
     "summary": {
       "total_commits": 2,
-      "implementation_commits": 1,
-      "plan_commits": 0,
-      "checkpoint_commits": 1
+      "implementation_commits": 2,
+      "plan_commits": 0
     }
   },
   "success": true,
@@ -264,13 +284,13 @@ Your entire response MUST be valid JSON. Do not include any text before or after
       {
         "sha": "abc1234567890def",
         "short_sha": "abc1234",
-        "message": "conductor(plan): Mark task complete",
-        "type": "plan-update"
+        "message": "feat(auth): Add login endpoint",
+        "type": "implementation"
       },
       {
         "sha": "def5678901234abc",
         "short_sha": "def5678",
-        "message": "feat(auth): Add login endpoint",
+        "message": "feat(auth): Add user registration",
         "type": "implementation"
       }
     ],

--- a/commands/implement.md
+++ b/commands/implement.md
@@ -190,16 +190,18 @@ d. **Execute per Workflow (FROM CACHE):** Follow the Workflow's "Task Workflow" 
 
 e. **Capture Decisions** per Section 3.6 when significant decision points arise
 
-f. **Mark Complete:** `python ${CLAUDE_PLUGIN_ROOT}/scripts/conductor_cli.py tracks update-task <track_id> <phase_idx> <task_idx> completed`
+f. **If this is the LAST task:** Before committing, run Step 5 (Finalize Track) first so that `metadata.json` is updated and staged with this commit.
+
+g. **Mark Complete:** `python ${CLAUDE_PLUGIN_ROOT}/scripts/conductor_cli.py tracks update-task <track_id> <phase_idx> <task_idx> completed`
 
 ### Step 5: Finalize Track
 
 After all tasks complete:
 
 1. **Run Auto Code Review** (Section 3.7)
-2. **Update status:** `python ${CLAUDE_PLUGIN_ROOT}/scripts/conductor_cli.py implement update-status <track_id> completed`
-   - **Fallback:** Manually change `[~]` to `[x]` in tracks.md
-3. **Commit:** Stage tracks.md, any uncommitted plan.md changes, and review files. Message: `chore(conductor): Mark track '<description>' as complete`
+2. **Update status BEFORE committing the last task:** `python ${CLAUDE_PLUGIN_ROOT}/scripts/conductor_cli.py implement update-status <track_id> completed`
+   - **Fallback:** Manually edit `conductor/tracks/<track_id>/metadata.json`, set `status` to `"completed"`.
+   - **CRITICAL:** This MUST happen before the last task's commit so that `metadata.json` is staged and included in that commit. Do NOT create a separate commit for track completion.
 
 ---
 
@@ -308,7 +310,7 @@ Prepare agent input from the CLI response:
 2. Identify new features, functionality changes, or tech updates
 3. For each document needing changes, present diff to user for approval
 4. Apply only after explicit confirmation
-5. Commit: `docs(conductor): Synchronize docs for track '<description>'`
+5. **Note:** Documentation updates should be bundled into the last code commit or left as uncommitted changes for the user to include in their next commit. Do NOT create a separate conductor-specific commit for docs sync.
 
 | Document | Update When | Confirmation |
 |----------|-------------|-------------|
@@ -329,6 +331,6 @@ Prepare agent input from the CLI response:
 | C. Skip | Leave in tracks file | None |
 
 1. Prompt user with A/B/C
-2. Archive: Run CLI, commit `chore(conductor): Archive track '<description>'`
+2. Archive: Run CLI, commit `chore: Archive track '<description>'`
 3. Delete: Require explicit confirmation, delete folder
 4. Commit changes

--- a/commands/newTrack.md
+++ b/commands/newTrack.md
@@ -210,8 +210,21 @@ After completing the protocol, proceed to **Section 2.0 NEW TRACK INITIALIZATION
 
 #### Commit and Finalize
 
-5.  **Confirm Commit:** Use AskUserQuestion with Commit pattern (Commit now/Skip commit), following constraints in `<protocol name="askuserquestion">`
-6.  **Commit (if confirmed):** `git add conductor/tracks/<track_id>/* && git commit -m "conductor(track): Create track '<description>'"`
+5.  **Confirm Commit:** Use AskUserQuestion to ask whether to commit track files now or defer:
+    ```json
+    {
+      "questions": [{
+        "question": "Track files created. Would you like to commit them now or bundle with the first task commit?",
+        "header": "Track Commit",
+        "options": [
+          {"label": "Commit now", "description": "Commit track files (spec.md, plan.md, metadata.json) as a separate commit"},
+          {"label": "Defer to first task", "description": "Leave track files uncommitted — they'll be included in the first task's code commit"}
+        ],
+        "multiSelect": false
+      }]
+    }
+    ```
+6.  **Commit (if confirmed):** `git add conductor/tracks/<track_id>/* && git commit -m "chore: Create track '<description>'"` — use a standard commit type, not a conductor-specific prefix.
 7.  **Announce:** Inform user track is created. Next step: `/conductor:implement`
 
 </instructions>

--- a/conductor/tracks/remove-conductor-specific-git_20260311/decisions.md
+++ b/conductor/tracks/remove-conductor-specific-git_20260311/decisions.md
@@ -1,0 +1,5 @@
+# Decisions: Remove Conductor-Specific Git Commits
+
+> **Track ID:** `remove-conductor-specific-git_20260311`
+
+*No decisions recorded yet.*

--- a/conductor/tracks/remove-conductor-specific-git_20260311/index.md
+++ b/conductor/tracks/remove-conductor-specific-git_20260311/index.md
@@ -1,0 +1,6 @@
+# Track: Remove Conductor-Specific Git Commits
+
+- [Specification](./spec.md)
+- [Implementation Plan](./plan.md)
+- [Metadata](./metadata.json)
+- [Decisions](./decisions.md)

--- a/conductor/tracks/remove-conductor-specific-git_20260311/metadata.json
+++ b/conductor/tracks/remove-conductor-specific-git_20260311/metadata.json
@@ -1,0 +1,8 @@
+{
+  "type": "feature",
+  "status": "completed",
+  "created_at": "2026-03-11T19:55:47.808883Z",
+  "updated_at": "2026-03-11T20:14:38.172400Z",
+  "description": "Remove conductor-specific git commits",
+  "track_id": "remove-conductor-specific-git_20260311"
+}

--- a/conductor/tracks/remove-conductor-specific-git_20260311/plan.md
+++ b/conductor/tracks/remove-conductor-specific-git_20260311/plan.md
@@ -1,0 +1,24 @@
+# Implementation Plan: Remove Conductor-Specific Git Commits
+
+> **Track ID:** `remove-conductor-specific-git_20260311`
+> **Type:** feature
+
+## Phase 1: Core Workflow Protocol Changes
+
+- [x] Task: Update `conductor/workflow.md` — Remove checkpoint commit step from Phase Completion Verification, bundle plan.md updates into code commits instead of separate checkpoint commits
+- [x] Task: Update `templates/workflow.md` — Mirror the same changes for new project templates
+- [x] Task: Conductor - User Manual Verification 'Phase 1' (Protocol in workflow.md)
+
+## Phase 2: Command Protocol Changes
+
+- [x] Task: Update `commands/implement.md` — Remove track completion commit (`chore(conductor): Mark track...`), remove docs sync commit (`docs(conductor): Synchronize docs...`), bundle these into the last code commit
+- [x] Task: Update `commands/newTrack.md` — Replace the automatic track creation commit with an AskUserQuestion prompt giving the user the choice to commit separately or defer
+- [x] Task: Conductor - User Manual Verification 'Phase 2' (Protocol in workflow.md)
+
+## Phase 3: Supporting Files
+
+- [x] Task: Update `skills/conductor-methodology/SKILL.md` — Remove all conductor-specific commit patterns from commit message documentation
+- [x] Task: Update `agents/git-history-analyst.md` — Replace conductor commit prefix grep patterns with alternative track identification strategies (metadata.json, plan.md references)
+- [x] Task: Update `CONTRIBUTING.md` — Remove or update the warning about conductor-specific commit types
+- [x] Task: Update `TESTING.md` — Update test examples to reflect new commit patterns
+- [x] Task: Conductor - User Manual Verification 'Phase 3' (Protocol in workflow.md)

--- a/conductor/tracks/remove-conductor-specific-git_20260311/spec.md
+++ b/conductor/tracks/remove-conductor-specific-git_20260311/spec.md
@@ -1,0 +1,64 @@
+# Specification: Remove Conductor-Specific Git Commits
+
+> **Type:** feature
+> **Track ID:** `remove-conductor-specific-git_20260311`
+
+## Overview
+
+Conductor currently produces its own git commits with conductor-specific prefixes (`conductor(track):`, `conductor(checkpoint):`, `chore(conductor):`, `docs(conductor):`). These add noise to git history and don't carry meaningful code changes. This track removes all conductor-specific commits by bundling conductor artifact changes (plan.md, metadata.json, etc.) into the actual feature/code commits they relate to.
+
+## Background
+
+After the prior `reduce-conductor-commit-noise` refactor, the remaining conductor-specific commits are:
+- **Track creation:** `conductor(track): Create track '<description>'` — commits spec.md, plan.md, metadata.json, etc.
+- **Phase checkpoints:** `conductor(checkpoint): Checkpoint end of Phase X` — commits accumulated plan.md updates
+- **Track completion:** `chore(conductor): Mark track '<description>' as complete`
+- **Docs sync:** `docs(conductor): Synchronize docs for track '<description>'`
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-1: Remove phase checkpoint commits** — Plan.md updates and phase status changes are bundled into the next task's code commit, or into the final task commit of the phase. Plan.md remains updated on disk after each task for status tracking.
+- **FR-2: Remove track completion commits** — Track completion status update is bundled into the last code commit of the track.
+- **FR-3: Remove docs sync commits** — Documentation synchronization is bundled into the relevant code commit.
+- **FR-4: Ask user about track creation commit** — At track creation time, ask the user whether to commit track files (spec.md, plan.md, metadata.json, etc.) as a separate commit or leave them uncommitted to be bundled with the first task commit.
+- **FR-5: Update git-history-analyst** — Update the git history analysis agent to no longer rely on conductor-specific commit prefixes for identifying track-related commits.
+- **FR-6: Update conductor-methodology skill** — Remove conductor-specific commit patterns from the skill's commit message documentation.
+
+### Non-Functional Requirements
+
+- **NFR-1:** Changes must be applied consistently across: `commands/implement.md`, `commands/newTrack.md`, `conductor/workflow.md`, `templates/workflow.md`, `skills/conductor-methodology/SKILL.md`, `agents/git-history-analyst.md`
+- **NFR-2:** `plan.md` must always reflect current state on disk so `/conductor:status` works correctly
+- **NFR-3:** No changes to CLI scripts — this is purely a protocol/workflow change
+- **NFR-4:** The `/conductor:revert` command logic should still work (may need updated heuristics)
+
+## Acceptance Criteria
+
+- No commits with `conductor(` prefix appear in the workflow protocols
+- Track creation offers a user choice: commit separately (with standard commit type like `chore:`) or defer
+- Phase checkpoint verification still happens but doesn't create its own commit — plan updates ride along with code commits
+- `git-history-analyst` uses alternative strategies (track metadata, plan.md references) instead of conductor commit prefixes
+- CONTRIBUTING.md warning about conductor commit types is updated/removed
+- TESTING.md examples are updated to reflect new commit patterns
+
+## Out of Scope
+
+- Changes to CLI scripts (`conductor_cli.py`)
+- Changes to `/conductor:setup` (setup commit stays — it's a one-time project init)
+- Changes to `/conductor:revert` internals (separate track if needed)
+- Removing git notes (they remain opt-in)
+
+## Dependencies
+
+- None identified
+
+## References
+
+- `commands/implement.md` - Implementation command protocol
+- `commands/newTrack.md` - Track creation command protocol
+- `conductor/workflow.md` - Project workflow (active)
+- `templates/workflow.md` - Workflow template (for new projects)
+- `skills/conductor-methodology/SKILL.md` - Conductor methodology skill
+- `agents/git-history-analyst.md` - Git history analysis agent
+- `conductor/tracks/archive/reduce-conductor-commit-noise_20260207/spec.md` - Prior related refactor

--- a/conductor/workflow.md
+++ b/conductor/workflow.md
@@ -44,7 +44,12 @@ All tasks follow a strict lifecycle:
    - Add dated note explaining the change
    - Resume implementation
 
-8. **Confirm Commit:**
+8. **Update Plan Status (Pre-Commit):**
+   - Read `plan.md`, find the line for the current task, update its status from `[~]` to `[x]`.
+   - Do NOT append a commit SHA yet — that happens after the commit in Step 12.
+   - Write the updated content back to `plan.md`.
+
+9. **Confirm Commit:**
    Before committing, ask the user for confirmation using AskUserQuestion:
    ```json
    {
@@ -59,37 +64,33 @@ All tasks follow a strict lifecycle:
      }]
    }
    ```
-   - **If "Commit now":** Proceed to Step 9 (Commit Code Changes)
-   - **If "Skip commit":** Skip to Step 12 (Update Plan Status), marking the task complete without a commit SHA
+   - **If "Commit now":** Proceed to Step 10 (Commit Code Changes)
+   - **If "Skip commit":** Skip to Step 12 (Record Commit SHA), marking the task complete without a commit SHA
 
-9. **Commit Code Changes (Conditional):**
-   **Only execute this step if user confirmed "Commit now" in Step 8.**
-   - Stage all code changes related to the task.
-   - Propose a clear, concise commit message e.g, `feat(ui): Create basic HTML structure for calculator`.
-   - Perform the commit.
+10. **Commit Code Changes (Conditional):**
+    **Only execute this step if user confirmed "Commit now" in Step 9.**
+    - Stage all code changes related to the task.
+    - **Also stage `plan.md`** to include the task status update and any accumulated updates from prior tasks.
+    - **If this is the last task of the track:** Also stage `metadata.json` (track status must have been updated to `completed` before this step).
+    - Propose a clear, concise commit message e.g, `feat(ui): Create basic HTML structure for calculator`.
+    - Perform the commit.
 
-10. **Attach Task Summary with Git Notes (Optional):**
-    **Only execute this step if Step 9 was executed and the team uses git notes.**
-    - **Step 10.1: Get Commit Hash:** Obtain the hash of the *just-completed commit* (`git log -1 --format="%H"`).
-    - **Step 10.2: Draft Note Content:** Create a detailed summary for the completed task. This should include the task name, a summary of changes, a list of all created/modified files, and the core "why" for the change.
-    - **Step 10.3: Attach Note:** Use the `git notes` command to attach the summary to the commit.
+11. **Attach Task Summary with Git Notes (Optional):**
+    **Only execute this step if Step 10 was executed and the team uses git notes.**
+    - **Step 11.1: Get Commit Hash:** Obtain the hash of the *just-completed commit* (`git log -1 --format="%H"`).
+    - **Step 11.2: Draft Note Content:** Create a detailed summary for the completed task. This should include the task name, a summary of changes, a list of all created/modified files, and the core "why" for the change.
+    - **Step 11.3: Attach Note:** Use the `git notes` command to attach the summary to the commit.
       ```bash
       # The note content from the previous step is passed via the -m flag.
       git notes add -m "<note content>" <commit_hash>
       ```
     - **Note:** Git notes are optional. If your team prefers not to use git notes, skip this step. The commit message and plan.md provide core traceability.
 
-11. **Get Task Commit SHA (Conditional):**
-    **Only execute this step if Step 9 was executed.**
-    - Obtain the first 7 characters of the commit hash for use in the next step.
-
-12. **Update Plan Status (On Disk Only - Do NOT Commit):**
-    - **Step 12.1: Get Commit SHA (if applicable):** If Step 9 was executed, obtain the first 7 characters of the commit hash.
-    - **Step 12.2: Update Plan:** Read `plan.md`, find the line for the completed task, update its status from `[~]` to `[x]`.
-      - **If Step 9 was executed:** Append the commit SHA (e.g., `- [x] Task: Description [abc1234]`).
-      - **If commit was skipped:** Mark complete without SHA (e.g., `- [x] Task: Description [uncommitted]`).
+12. **Record Commit SHA in Plan (On Disk Only - Do NOT Commit):**
+    - **Step 12.1: Get Commit SHA (if applicable):** If Step 10 was executed, obtain the first 7 characters of the commit hash.
+    - **Step 12.2: Update Plan:** Read `plan.md`, find the completed task line, and append the commit SHA (e.g., `- [x] Task: Description [abc1234]`). If no commit was made, append `[uncommitted]`.
     - **Step 12.3: Write Plan:** Write the updated content back to `plan.md`.
-    - **IMPORTANT:** Do NOT commit `plan.md` separately. The plan update will be included in the next phase checkpoint commit. This keeps `plan.md` up-to-date on disk for status tracking while reducing commit noise.
+    - **IMPORTANT:** Do NOT commit `plan.md` separately. The SHA annotation will be included in the next task's code commit. This keeps `plan.md` up-to-date on disk for status tracking.
 
 ### Phase Completion Verification and Checkpointing Protocol
 
@@ -140,21 +141,13 @@ All tasks follow a strict lifecycle:
     -   After presenting the detailed plan, ask the user for confirmation: "**Does this meet your expectations? Please confirm with yes or provide feedback on what needs to be changed.**"
     -   **PAUSE** and await the user's response. Do not proceed without an explicit yes or confirmation.
 
-6.  **Create Checkpoint Commit (Includes Accumulated Plan Updates):**
-    -   Stage all changes, **including the modified `plan.md`** which contains accumulated task status updates from this phase.
-    -   Perform the commit with a clear and concise message (e.g., `conductor(checkpoint): Checkpoint end of Phase X`).
+6.  **Record Phase Reference (On Disk Only - Do NOT Commit):**
+    -   **Step 6.1: Get Last Commit Hash:** Obtain the hash of the last task commit in this phase (`git log -1 --format="%H"`).
+    -   **Step 6.2: Update Plan:** Read `plan.md`, find the heading for the completed phase, and append the first 7 characters of the commit hash in the format `[checkpoint: <sha>]`.
+    -   **Step 6.3: Write Plan:** Write the updated content back to `plan.md`.
+    -   **IMPORTANT:** Do NOT commit this change separately. The checkpoint SHA annotation will be included in the next phase's first task commit.
 
-7.  **Attach Auditable Verification Report using Git Notes:**
-    -   **Step 7.1: Draft Note Content:** Create a detailed verification report including the automated test command, the manual verification steps, and the user's confirmation.
-    -   **Step 7.2: Attach Note:** Use the `git notes` command and the full commit hash from the previous step to attach the full report to the checkpoint commit.
-
-8.  **Get and Record Phase Checkpoint SHA (On Disk Only - Do NOT Commit):**
-    -   **Step 8.1: Get Commit Hash:** Obtain the hash of the *just-created checkpoint commit* (`git log -1 --format="%H"`).
-    -   **Step 8.2: Update Plan:** Read `plan.md`, find the heading for the completed phase, and append the first 7 characters of the commit hash in the format `[checkpoint: <sha>]`.
-    -   **Step 8.3: Write Plan:** Write the updated content back to `plan.md`.
-    -   **IMPORTANT:** Do NOT commit this change separately. The checkpoint SHA annotation will be included in the next phase's checkpoint commit, or remain as an uncommitted working state after the final phase.
-
-9.  **Announce Completion:** Inform the user that the phase is complete and the checkpoint has been created.
+7.  **Announce Completion:** Inform the user that the phase is complete and verified.
 
 ### Quality Gates
 

--- a/skills/conductor-methodology/SKILL.md
+++ b/skills/conductor-methodology/SKILL.md
@@ -99,10 +99,11 @@ Standard workflow from `workflow.md`:
 5. **Refactor**: Improve code while keeping tests passing
 6. **Verify Coverage**: Ensure >80% coverage (or configured percentage)
 7. **Document Deviations**: Update tech-stack.md if needed
-8. **Commit Code**: Stage and commit with descriptive message
-9. **Attach Task Summary**: Use git notes for detailed summary
-10. **Record SHA**: Update plan with commit hash
-11. **Commit Plan**: Commit plan.md changes
+8. **Update Plan Status**: Mark task as `[x]` in plan.md (pre-commit)
+9. **Confirm Commit**: Ask user to commit or skip
+10. **Commit Code + Plan**: Stage code changes and plan.md together, commit with descriptive message
+11. **Attach Task Summary**: Use git notes for detailed summary (optional)
+12. **Record SHA in Plan**: Append commit SHA to task line on disk (included in next commit)
 
 ### Phase Completion Protocol
 
@@ -112,21 +113,19 @@ When a phase completes:
 2. **Execute Automated Tests**: Run full test suite with `CI=true`
 3. **Propose Manual Verification Plan**: Provide step-by-step verification steps
 4. **Await User Feedback**: Get explicit confirmation
-5. **Create Checkpoint Commit**: Commit with message `conductor(checkpoint): Checkpoint end of Phase X`
-6. **Attach Verification Report**: Use git notes with test results and user confirmation
-7. **Record Checkpoint SHA**: Append to phase header in plan
-8. **Commit Plan Update**: Commit plan changes
+5. **Record Phase Reference**: Get last task commit SHA, append `[checkpoint: <sha>]` to phase header in plan (on disk only)
+6. **Announce Completion**: Inform user the phase is complete and verified
 
 ### Commit Message Patterns
 
 - **Implementation**: `feat(module): Add feature description`
 - **Bug Fix**: `fix(module): Fix issue description`
 - **Tests**: `test(module): Add tests for feature`
-- **Plan Updates**: `conductor(plan): Mark task 'description' as complete`
-- **Checkpoints**: `conductor(checkpoint): Checkpoint end of Phase X`
-- **Track Management**: `conductor(track): Create track 'description'`
-- **Setup**: `conductor(setup): Add conductor setup files`
-- **Documentation**: `docs(conductor): Synchronize docs for track 'description'`
+- **Refactoring**: `refactor(module): Refactor description`
+- **Documentation**: `docs(module): Update documentation`
+- **Chores**: `chore: Maintenance task description`
+
+**Note:** Plan.md updates are bundled into code commits — no separate conductor-specific commits are created. Track creation uses standard commit types (e.g., `chore: Create track 'description'`).
 
 ## Git Notes Usage
 
@@ -144,9 +143,9 @@ Files Changed:
 Why: <Rationale for changes>
 ```
 
-### Checkpoint Notes
+### Phase Verification Notes
 
-Attached to checkpoint commits with format:
+Optionally attached to the last task commit of a phase:
 ```
 Phase: <Phase Name>
 Automated Tests: <Command run and result>

--- a/templates/workflow.md
+++ b/templates/workflow.md
@@ -44,50 +44,77 @@ All tasks follow a strict lifecycle:
    - Add dated note explaining the change
    - Resume implementation
 
-8. **Commit Code Changes:**
-   - Stage all code changes related to the task.
-   - Propose a clear, concise commit message e.g, `feat(ui): Create basic HTML structure for calculator`.
-   - Perform the commit.
+8. **Update Plan Status (Pre-Commit):**
+   - Read `plan.md`, find the line for the current task, update its status from `[~]` to `[x]`.
+   - Do NOT append a commit SHA yet — that happens after the commit in Step 12.
+   - Write the updated content back to `plan.md`.
 
-9. **Attach Task Summary with Git Notes (Optional):**
-   - **Step 9.1: Get Commit Hash:** Obtain the hash of the *just-completed commit* (`git log -1 --format="%H"`).
-   - **Step 9.2: Draft Note Content:** Create a detailed summary using the enhanced format below.
-   - **Step 9.3: Attach Note:** Use the `git notes` command to attach the summary to the commit.
-     ```bash
-     git notes add -m "<note content>" <commit_hash>
-     ```
-
-   **Enhanced Git Note Format:**
-   ```markdown
-   ## Task: [Task Name]
-
-   ### Summary
-   [Brief description of what was accomplished]
-
-   ### Why
-   [The rationale behind this implementation - why this approach was chosen]
-
-   ### Changes
-   - [List of changes made]
-   - [Files created/modified]
-
-   ### Decisions Made
-   [Reference any ADRs recorded during this task]
-   - ADR-001: [Decision title] (see decisions.md)
-   - ADR-002: [Decision title] (see decisions.md)
-
-   ### Files Modified
-   - path/to/file1.ext
-   - path/to/file2.ext
+9. **Confirm Commit:**
+   Before committing, ask the user for confirmation using AskUserQuestion:
+   ```json
+   {
+     "questions": [{
+       "question": "The task implementation is complete. Would you like to commit the changes now?",
+       "header": "Commit",
+       "options": [
+         {"label": "Commit now", "description": "Stage and commit all code changes"},
+         {"label": "Skip commit", "description": "Leave changes uncommitted for now"}
+       ],
+       "multiSelect": false
+     }]
+   }
    ```
+   - **If "Commit now":** Proceed to Step 10 (Commit Code Changes)
+   - **If "Skip commit":** Skip to Step 12 (Record Commit SHA), marking the task complete without a commit SHA
 
-   **Note:** Git notes are optional. If your team prefers not to use git notes, skip this step. The commit message and plan.md provide core traceability.
+10. **Commit Code Changes (Conditional):**
+    **Only execute this step if user confirmed "Commit now" in Step 9.**
+    - Stage all code changes related to the task.
+    - **Also stage `plan.md`** to include the task status update and any accumulated updates from prior tasks.
+    - **If this is the last task of the track:** Also stage `metadata.json` (track status must have been updated to `completed` before this step).
+    - Propose a clear, concise commit message e.g, `feat(ui): Create basic HTML structure for calculator`.
+    - Perform the commit.
 
-10. **Update Plan Status (On Disk Only - Do NOT Commit):**
-    - **Step 10.1: Get Commit SHA (if applicable):** If Step 9 was executed, obtain the first 7 characters of the commit hash.
-    - **Step 10.2: Update Plan:** Read `plan.md`, find the line for the completed task, update its status from `[~]` to `[x]`, and append the commit SHA (e.g., `- [x] Task: Description [abc1234]`). If no commit was made, use `[uncommitted]`.
-    - **Step 10.3: Write Plan:** Write the updated content back to `plan.md`.
-    - **IMPORTANT:** Do NOT commit `plan.md` separately. The plan update will be included in the next phase checkpoint commit. This keeps `plan.md` up-to-date on disk for status tracking while reducing commit noise.
+11. **Attach Task Summary with Git Notes (Optional):**
+    **Only execute this step if Step 10 was executed and the team uses git notes.**
+    - **Step 11.1: Get Commit Hash:** Obtain the hash of the *just-completed commit* (`git log -1 --format="%H"`).
+    - **Step 11.2: Draft Note Content:** Create a detailed summary using the enhanced format below.
+    - **Step 11.3: Attach Note:** Use the `git notes` command to attach the summary to the commit.
+      ```bash
+      git notes add -m "<note content>" <commit_hash>
+      ```
+
+    **Enhanced Git Note Format:**
+    ```markdown
+    ## Task: [Task Name]
+
+    ### Summary
+    [Brief description of what was accomplished]
+
+    ### Why
+    [The rationale behind this implementation - why this approach was chosen]
+
+    ### Changes
+    - [List of changes made]
+    - [Files created/modified]
+
+    ### Decisions Made
+    [Reference any ADRs recorded during this task]
+    - ADR-001: [Decision title] (see decisions.md)
+    - ADR-002: [Decision title] (see decisions.md)
+
+    ### Files Modified
+    - path/to/file1.ext
+    - path/to/file2.ext
+    ```
+
+    **Note:** Git notes are optional. If your team prefers not to use git notes, skip this step. The commit message and plan.md provide core traceability.
+
+12. **Record Commit SHA in Plan (On Disk Only - Do NOT Commit):**
+    - **Step 12.1: Get Commit SHA (if applicable):** If Step 10 was executed, obtain the first 7 characters of the commit hash.
+    - **Step 12.2: Update Plan:** Read `plan.md`, find the completed task line, and append the commit SHA (e.g., `- [x] Task: Description [abc1234]`). If no commit was made, append `[uncommitted]`.
+    - **Step 12.3: Write Plan:** Write the updated content back to `plan.md`.
+    - **IMPORTANT:** Do NOT commit `plan.md` separately. The SHA annotation will be included in the next task's code commit. This keeps `plan.md` up-to-date on disk for status tracking.
 
 ### Phase Completion Verification and Checkpointing Protocol
 
@@ -138,22 +165,13 @@ All tasks follow a strict lifecycle:
     -   After presenting the detailed plan, ask the user for confirmation: "**Does this meet your expectations? Please confirm with yes or provide feedback on what needs to be changed.**"
     -   **PAUSE** and await the user's response. Do not proceed without an explicit yes or confirmation.
 
-6.  **Create Checkpoint Commit (Includes Accumulated Plan Updates):**
-    -   Stage all changes, **including the modified `plan.md`** which contains accumulated task status updates from this phase.
-    -   Perform the commit with a clear and concise message (e.g., `conductor(checkpoint): Checkpoint end of Phase X`).
+6.  **Record Phase Reference (On Disk Only - Do NOT Commit):**
+    -   **Step 6.1: Get Last Commit Hash:** Obtain the hash of the last task commit in this phase (`git log -1 --format="%H"`).
+    -   **Step 6.2: Update Plan:** Read `plan.md`, find the heading for the completed phase, and append the first 7 characters of the commit hash in the format `[checkpoint: <sha>]`.
+    -   **Step 6.3: Write Plan:** Write the updated content back to `plan.md`.
+    -   **IMPORTANT:** Do NOT commit this change separately. The checkpoint SHA annotation will be included in the next phase's first task commit.
 
-7.  **Attach Auditable Verification Report using Git Notes (Optional):**
-    -   **Step 7.1: Draft Note Content:** Create a detailed verification report including the automated test command, the manual verification steps, and the user's confirmation.
-    -   **Step 7.2: Attach Note:** Use the `git notes` command and the full commit hash from the previous step to attach the full report to the checkpoint commit.
-    -   **Note:** This step is optional. If your team prefers not to use git notes, skip this step.
-
-8.  **Get and Record Phase Checkpoint SHA (On Disk Only - Do NOT Commit):**
-    -   **Step 8.1: Get Commit Hash:** Obtain the hash of the *just-created checkpoint commit* (`git log -1 --format="%H"`).
-    -   **Step 8.2: Update Plan:** Read `plan.md`, find the heading for the completed phase, and append the first 7 characters of the commit hash in the format `[checkpoint: <sha>]`.
-    -   **Step 8.3: Write Plan:** Write the updated content back to `plan.md`.
-    -   **IMPORTANT:** Do NOT commit this change separately. The checkpoint SHA annotation will be included in the next phase's checkpoint commit, or remain as an uncommitted working state after the final phase.
-
-9.  **Announce Completion:** Inform the user that the phase is complete and the checkpoint has been created.
+7.  **Announce Completion:** Inform the user that the phase is complete and verified.
 
 ### Quality Gates
 


### PR DESCRIPTION
## Summary

- **Bundle plan.md updates into code commits** instead of separate `conductor(checkpoint)` commits — workflow steps restructured so plan status is updated pre-commit and staged alongside code
- **Remove all conductor-specific commit patterns** (`conductor(track):`, `conductor(checkpoint):`, `chore(conductor):`, `docs(conductor):`) from workflow protocols, command protocols, SKILL.md, and git-history-analyst
- **Track creation now offers user choice** to commit separately (with standard `chore:` type) or defer to first task commit
- **Ensure metadata.json is included in last commit** — `update-status` must run before the final commit so track completion status is bundled in

## Files Changed

- `conductor/workflow.md` / `templates/workflow.md` — Restructured task steps 8-12, removed checkpoint commit from phase completion
- `commands/implement.md` — Removed track completion and docs sync commits, added metadata.json staging rule
- `commands/newTrack.md` — Replaced `conductor(track):` with `chore:`, added defer option
- `skills/conductor-methodology/SKILL.md` — Removed conductor-specific commit patterns
- `agents/git-history-analyst.md` — Replaced prefix grep with file/branch/plan.md-based detection
- `CONTRIBUTING.md` — Removed `conductor(track):` example from Release Please warning
- `TESTING.md` — Updated test expectations for new commit patterns

## Test plan

- [x] 188 Python CLI tests pass
- [x] Verify no `conductor(` commit prefixes remain in active protocol files (only in archive/spec)
- [x] Verify backwards compatibility note exists in git-history-analyst for legacy repos