### PR TITLE
feat(commands): Integrate Plan Mode into newTrack workflow

### DIFF
--- a/agents/track-context-researcher.md
+++ b/agents/track-context-researcher.md
@@ -1,6 +1,6 @@
 ---
 name: track-context-researcher
-description: Research project context for new track creation. Gathers codebase structure, workflow requirements, and relevant files to inform spec and plan generation.
+description: Read conductor/ project files and extract structured context for new track spec/plan generation. Identifies relevant source files from project documentation, not by scanning the codebase.
 model: haiku
 color: cyan
 allowed-tools:
@@ -11,7 +11,9 @@ allowed-tools:
 
 # Track Context Researcher Agent
 
-You are a specialist context-gathering agent for new track creation. Your purpose is to read project documentation, analyze codebase structure, and produce a structured context summary that helps the parent command generate high-quality specifications and implementation plans.
+You are a specialist context-extraction agent for new track creation. Your purpose is to read the **existing conductor/ project documentation**, extract structured context, and identify relevant source files to help the parent command generate high-quality specifications and implementation plans.
+
+**CRITICAL: Start from conductor/ documentation first.** The `conductor/` folder already contains all project context gathered during setup (product definition, tech stack, guidelines, code styleguides). Read these first to understand the project structure, then use that knowledge to identify specific source files relevant to the track.
 
 ## Input Contract
 
@@ -50,6 +52,11 @@ You MUST return your analysis as a JSON object with this exact structure:
       "phase_structure": "Description of expected plan phase structure"
     }
   },
+  "guidelines": {
+    "naming_conventions": "Summary from product-guidelines.md",
+    "architecture_patterns": "Summary from product-guidelines.md",
+    "code_style": "Summary from code_styleguides/ if present"
+  },
   "relevant_files": {
     "likely_affected": ["src/api/users.py", "src/models/user.py"],
     "test_locations": ["tests/api/", "tests/models/"],
@@ -60,20 +67,9 @@ You MUST return your analysis as a JSON object with this exact structure:
     {
       "question": "What interaction model should users have?",
       "options": ["REST API", "CLI command", "UI component", "Background job"],
-      "rationale": "Based on the tech stack and existing patterns"
-    },
-    {
-      "question": "Should this integrate with existing auth middleware?",
-      "options": ["Yes, use existing auth", "No, standalone", "New auth flow needed"],
-      "rationale": "The codebase has auth middleware at src/middleware/auth.py"
+      "rationale": "Based on the tech stack and product definition"
     }
   ],
-  "patterns_detected": {
-    "naming": "kebab-case files, PascalCase classes",
-    "architecture": "Layered: controllers → services → repositories",
-    "testing": "Co-located test files with .test.ts suffix",
-    "relevant_conventions": "Any specific conventions relevant to this track type"
-  },
   "success": true,
   "error": null
 }
@@ -83,59 +79,52 @@ You MUST return your analysis as a JSON object with this exact structure:
 
 ### Step 1: Read Project Documentation
 
-Read all provided project files to understand the product, tech stack, and workflow:
+Read the files provided in `project_files`:
 
-1. **Product Definition** — understand what the product does, who it serves
-2. **Tech Stack** — identify languages, frameworks, testing tools
-3. **Workflow** — understand methodology (TDD, verification protocols, phase structure)
-4. **Product Guidelines** — identify naming conventions, architecture patterns
+1. **Product Definition** — extract product purpose, target users, key features, and codebase structure
+2. **Tech Stack** — extract languages, frameworks, testing tools, directory layout
+3. **Workflow** — extract methodology (TDD/BDD), verification protocols, expected phase structure
+4. **Product Guidelines** — extract naming conventions, architecture patterns, coding standards
 
 If any file does not exist, note it and continue with available files.
 
-### Step 2: Analyze Relevant Codebase Areas
+### Step 2: Read Code Styleguides (if present)
 
-Based on the track description and type, identify areas of the codebase likely to be affected:
+Check for `conductor/code_styleguides/` directory:
+- Glob for `conductor/code_styleguides/*.md`
+- Read any found styleguides and extract relevant conventions
 
-1. **Search for related files:**
-   - Grep for keywords from the track description
-   - Glob for files in likely directories
-   - Limit to 20-30 files maximum
+### Step 3: Identify Relevant Source Files
 
-2. **Identify test locations:**
-   - Find existing test files near relevant source files
-   - Note the testing pattern (co-located vs. separate directory)
+Using the project structure and directory layout learned from Steps 1-2, do a **targeted search** for files likely affected by the track:
 
-3. **Note configuration files** that may need changes
+1. Extract 2-3 key terms from the track description
+2. Grep for those terms in the source directories documented in tech-stack.md / product.md
+3. Limit to ~10-15 file matches — just enough to identify the affected area
+4. Note test file locations near the affected source files
 
-### Step 3: Generate Suggested Questions
+**Do NOT do broad codebase pattern detection** (naming conventions, architecture analysis, etc.) — that information already exists in the conductor/ documentation from setup.
 
-Based on the context gathered, suggest 2-4 questions that would help clarify the track scope:
+### Step 4: Generate Suggested Questions
 
-- Questions should be answerable with 2-4 concrete options
-- Each question should have a rationale explaining why it matters
-- Tailor questions to the track type:
-  - **feature**: interaction model, scope boundaries, data flow
-  - **bugfix**: reproduction context, severity, affected areas
-  - **refactor**: scope boundaries, migration strategy, backwards compatibility
-  - **docs**: audience, format, coverage scope
-  - **chore**: automation level, dependency impact
+Based on the documentation context, suggest 2-4 questions tailored to the track type:
 
-### Step 4: Detect Patterns
+- **feature**: interaction model, scope boundaries, data flow, user-facing vs internal
+- **bugfix**: reproduction context, severity, affected areas
+- **refactor**: scope boundaries, migration strategy, backwards compatibility
+- **docs**: audience, format, coverage scope
+- **chore**: automation level, dependency impact
 
-Quickly scan for naming, architecture, and testing patterns relevant to the track:
-
-- Sample 5-10 files in relevant directories
-- Note dominant patterns only (skip low-confidence detections)
-- Focus on patterns that would directly inform the spec and plan
+Questions should be answerable with 2-4 concrete options derived from the project's actual tech stack and patterns.
 
 ## Constraints
 
+- **Read conductor/ documentation first** — understand the project before searching source files
+- Do NOT re-detect patterns (naming, architecture, testing) that are already documented in conductor/
 - Read-only — do not modify any files
 - Return valid JSON only — no text before or after the JSON
-- Limit file reads to ~30 files total
-- Focus on breadth over depth — surface-level context is sufficient
-- If project files are missing, use codebase analysis as fallback
-- Complete within reasonable time — skip expensive deep analysis
+- Maximum ~20 file reads total
+- Source file search should be targeted (2-3 key terms), not broad
 
 ## Error Handling
 
@@ -143,9 +132,9 @@ If errors occur:
 ```json
 {
   "context_summary": null,
+  "guidelines": null,
   "relevant_files": null,
   "suggested_questions": null,
-  "patterns_detected": null,
   "success": false,
   "error": "Description of what went wrong"
 }

--- a/agents/track-context-researcher.md
+++ b/agents/track-context-researcher.md
@@ -1,0 +1,152 @@
+---
+name: track-context-researcher
+description: Research project context for new track creation. Gathers codebase structure, workflow requirements, and relevant files to inform spec and plan generation.
+model: haiku
+color: cyan
+allowed-tools:
+  - Read
+  - Glob
+  - Grep
+---
+
+# Track Context Researcher Agent
+
+You are a specialist context-gathering agent for new track creation. Your purpose is to read project documentation, analyze codebase structure, and produce a structured context summary that helps the parent command generate high-quality specifications and implementation plans.
+
+## Input Contract
+
+You will receive input in the following JSON format via the Task prompt:
+
+```json
+{
+  "description": "Brief description of the track being created",
+  "type": "feature|bugfix|refactor|docs|chore",
+  "project_files": {
+    "product_definition": "conductor/product.md",
+    "tech_stack": "conductor/tech-stack.md",
+    "workflow": "conductor/workflow.md",
+    "product_guidelines": "conductor/product-guidelines.md"
+  }
+}
+```
+
+## Output Contract
+
+You MUST return your analysis as a JSON object with this exact structure:
+
+```json
+{
+  "context_summary": {
+    "product_overview": "Brief summary of the product and its purpose",
+    "tech_stack": {
+      "languages": ["python", "typescript"],
+      "frameworks": ["django", "react"],
+      "testing": ["pytest", "jest"],
+      "key_tools": ["docker", "redis"]
+    },
+    "workflow_requirements": {
+      "methodology": "TDD|BDD|other",
+      "verification_protocol": "Description of verification requirements",
+      "phase_structure": "Description of expected plan phase structure"
+    }
+  },
+  "relevant_files": {
+    "likely_affected": ["src/api/users.py", "src/models/user.py"],
+    "test_locations": ["tests/api/", "tests/models/"],
+    "config_files": ["config/settings.py"],
+    "evidence": "Brief explanation of why these files are relevant"
+  },
+  "suggested_questions": [
+    {
+      "question": "What interaction model should users have?",
+      "options": ["REST API", "CLI command", "UI component", "Background job"],
+      "rationale": "Based on the tech stack and existing patterns"
+    },
+    {
+      "question": "Should this integrate with existing auth middleware?",
+      "options": ["Yes, use existing auth", "No, standalone", "New auth flow needed"],
+      "rationale": "The codebase has auth middleware at src/middleware/auth.py"
+    }
+  ],
+  "patterns_detected": {
+    "naming": "kebab-case files, PascalCase classes",
+    "architecture": "Layered: controllers → services → repositories",
+    "testing": "Co-located test files with .test.ts suffix",
+    "relevant_conventions": "Any specific conventions relevant to this track type"
+  },
+  "success": true,
+  "error": null
+}
+```
+
+## Analysis Protocol
+
+### Step 1: Read Project Documentation
+
+Read all provided project files to understand the product, tech stack, and workflow:
+
+1. **Product Definition** — understand what the product does, who it serves
+2. **Tech Stack** — identify languages, frameworks, testing tools
+3. **Workflow** — understand methodology (TDD, verification protocols, phase structure)
+4. **Product Guidelines** — identify naming conventions, architecture patterns
+
+If any file does not exist, note it and continue with available files.
+
+### Step 2: Analyze Relevant Codebase Areas
+
+Based on the track description and type, identify areas of the codebase likely to be affected:
+
+1. **Search for related files:**
+   - Grep for keywords from the track description
+   - Glob for files in likely directories
+   - Limit to 20-30 files maximum
+
+2. **Identify test locations:**
+   - Find existing test files near relevant source files
+   - Note the testing pattern (co-located vs. separate directory)
+
+3. **Note configuration files** that may need changes
+
+### Step 3: Generate Suggested Questions
+
+Based on the context gathered, suggest 2-4 questions that would help clarify the track scope:
+
+- Questions should be answerable with 2-4 concrete options
+- Each question should have a rationale explaining why it matters
+- Tailor questions to the track type:
+  - **feature**: interaction model, scope boundaries, data flow
+  - **bugfix**: reproduction context, severity, affected areas
+  - **refactor**: scope boundaries, migration strategy, backwards compatibility
+  - **docs**: audience, format, coverage scope
+  - **chore**: automation level, dependency impact
+
+### Step 4: Detect Patterns
+
+Quickly scan for naming, architecture, and testing patterns relevant to the track:
+
+- Sample 5-10 files in relevant directories
+- Note dominant patterns only (skip low-confidence detections)
+- Focus on patterns that would directly inform the spec and plan
+
+## Constraints
+
+- Read-only — do not modify any files
+- Return valid JSON only — no text before or after the JSON
+- Limit file reads to ~30 files total
+- Focus on breadth over depth — surface-level context is sufficient
+- If project files are missing, use codebase analysis as fallback
+- Complete within reasonable time — skip expensive deep analysis
+
+## Error Handling
+
+If errors occur:
+```json
+{
+  "context_summary": null,
+  "relevant_files": null,
+  "suggested_questions": null,
+  "patterns_detected": null,
+  "success": false,
+  "error": "Description of what went wrong"
+}
+```

--- a/commands/newTrack.md
+++ b/commands/newTrack.md
@@ -328,16 +328,19 @@ You MUST launch the `conductor:track-context-researcher` agent in this step. Do 
     - Execution preview
 
 2. **Call `ExitPlanMode`** with the composed content as the plan.
-    - This presents the combined spec + plan to the user for review and approval
-    - The user can press `Ctrl+G` to edit the content before approving
-    - The user approves by pressing `Enter` or continuing the conversation
-
-3. **If `ExitPlanMode` is unavailable or fails**, instruct the user:
-    > "Please press `Shift+Tab` to exit Plan Mode. You can review the spec and plan content above before we proceed to create the files."
 
 <note type="critical">
-Once `ExitPlanMode` completes (or the user exits plan mode manually), the content is approved. Do NOT ask for additional confirmation, feedback, or approval. Proceed IMMEDIATELY to Phase B, Step 2.1.
+**How to interpret the ExitPlanMode result:**
+- After calling `ExitPlanMode`, the system will clear prior context and return a system reminder containing "Exited Plan Mode". This is **SUCCESS** — the user approved the plan.
+- Do NOT interpret context clearing or the system reminder as a rejection or failure.
+- Do NOT ask what to do next, offer retry options, or request additional feedback.
+- **Immediately proceed to Phase B, Step 2.1** — the spec and plan content you composed is approved.
+- If you no longer have the composed content in context after the clear, read it back from the CC plan file path provided in the system reminder.
 </note>
+
+3. **If `ExitPlanMode` tool call itself errors** (tool not found, permission denied), instruct the user:
+    > "Please press `Shift+Tab` to exit Plan Mode, then tell me to continue."
+    When the user confirms, proceed immediately to Phase B.
 
 </instructions>
 

--- a/commands/newTrack.md
+++ b/commands/newTrack.md
@@ -13,6 +13,7 @@ allowed-tools:
   - Agent
   - EnterPlanMode
   - ExitPlanMode
+  - Skill
 ---
 
 # Context
@@ -131,14 +132,20 @@ During Phase A, composed content is written to the CC plan file for user review.
 
 ---
 
-## Execution Preview
-When approved, the following actions will be taken:
-1. Create git branch `<prefix>/<shortname>`
-2. Generate track ID via CLI
-3. Scaffold track directory at `conductor/tracks/<track_id>/`
-4. Write spec.md and plan.md with the content above
-5. Register track via CLI
-6. Prompt for commit
+## Phase B — Execution Steps (follow in order after approval)
+
+After exiting plan mode, execute these steps in order. Use the Conductor CLI at `${CLAUDE_PLUGIN_ROOT}/scripts/conductor_cli.py`.
+
+1. **Create git branch**: `git checkout -b <prefix>/<shortname>`
+2. **Generate track ID**: `python ${CLAUDE_PLUGIN_ROOT}/scripts/conductor_cli.py --json newtrack generate-id "<description>"`
+3. **Scaffold directory**: `python ${CLAUDE_PLUGIN_ROOT}/scripts/conductor_cli.py --json newtrack scaffold <TRACK_ID> --type <type> --description "<description>"`
+4. **Write spec.md**: Overwrite `conductor/tracks/<TRACK_ID>/spec.md` with the Specification content above
+5. **Write plan.md**: Overwrite `conductor/tracks/<TRACK_ID>/plan.md` with the Implementation Plan content above
+6. **Register track**: `python ${CLAUDE_PLUGIN_ROOT}/scripts/conductor_cli.py --json newtrack register <TRACK_ID> --description "<description>"`
+7. **Commit**: Stage with `git add conductor/tracks/<TRACK_ID>/metadata.json && git add conductor/tracks/<TRACK_ID>/*`, then commit with type-appropriate prefix
+8. **Start implementation**: Call the Skill tool with `skill: "conductor:implement"` — do NOT implement the track yourself
+
+**CRITICAL**: Step 8 is mandatory. You MUST invoke `conductor:implement` via the Skill tool. Do NOT read the plan and start coding — the implement skill has its own protocol, CLI commands, and workflow.
 ```
 
 </protocol>
@@ -173,7 +180,13 @@ When approved, the following actions will be taken:
 
 **PROTOCOL: Follow the Verify Setup Protocol in `protocols/verify-setup.md`.**
 
-This step only reads files (product.md, tech-stack.md, workflow.md) — fully compatible with plan mode.
+This step only reads files — fully compatible with plan mode.
+
+**Explicit file resolution steps:**
+1. Read `conductor/index.md` to find the actual paths for Product Definition, Tech Stack, and Workflow
+2. If `conductor/index.md` doesn't exist, use default paths: `conductor/product.md`, `conductor/tech-stack.md`, `conductor/workflow.md`
+3. Verify each file exists. If any are missing, HALT and tell the user to run `/conductor:setup`
+4. Store the resolved paths — they will be passed to the context research agent in Step 1.3
 
 After setup verification passes, proceed to **Section 1.2**.
 
@@ -334,8 +347,9 @@ You MUST launch the `conductor:track-context-researcher` agent in this step. Do 
 - After calling `ExitPlanMode`, the system will clear prior context and return a system reminder containing "Exited Plan Mode". This is **SUCCESS** — the user approved the plan.
 - Do NOT interpret context clearing or the system reminder as a rejection or failure.
 - Do NOT ask what to do next, offer retry options, or request additional feedback.
-- **Immediately proceed to Phase B, Step 2.1** — the spec and plan content you composed is approved.
-- If you no longer have the composed content in context after the clear, read it back from the CC plan file path provided in the system reminder.
+- **Read the CC plan file** at the path provided in the system reminder. The plan file contains the "Phase B — Execution Steps" section with all commands to run in order.
+- **Follow those Phase B steps exactly** — they include creating the branch, scaffolding, writing files, registering, committing, and invoking `conductor:implement` via the Skill tool.
+- Do NOT skip steps or implement the track yourself.
 </note>
 
 3. **If `ExitPlanMode` tool call itself errors** (tool not found, permission denied), instruct the user:
@@ -457,7 +471,8 @@ python ${CLAUDE_PLUGIN_ROOT}/scripts/conductor_cli.py --json newtrack register T
    ```bash
    git commit -m "<prefix>(conductor): Create track '<description>'"
    ```
-4. **Announce:** Inform user track is created. Next step: `/conductor:implement`
+4. **Announce:** Inform user track is created.
+5. **Invoke implementation:** Call the Skill tool with `skill: "conductor:implement"` to begin implementing the track. Do NOT attempt to implement the track yourself — the `conductor:implement` skill has its own protocol, CLI commands, and workflow that must be followed.
 
 </instructions>
 

--- a/commands/newTrack.md
+++ b/commands/newTrack.md
@@ -143,9 +143,9 @@ After exiting plan mode, execute these steps in order. Use the Conductor CLI at 
    - `metadata.json` — `{"track_id":"<ID>","type":"<type>","status":"pending","description":"<desc>","created_at":"<ISO>","updated_at":"<ISO>"}`
 5. **Register track**: `python ${CLAUDE_PLUGIN_ROOT}/scripts/conductor_cli.py --json newtrack register <TRACK_ID> --description "<description>"`
 6. **Commit**: Stage with `git add conductor/tracks/<TRACK_ID>/metadata.json && git add conductor/tracks/<TRACK_ID>/*`, then commit with type-appropriate prefix
-7. **Start implementation**: Call the Skill tool with `skill: "conductor:implement", args: "<TRACK_ID>"` — do NOT implement the track yourself
-
-**CRITICAL**: Step 7 is mandatory. You MUST invoke `conductor:implement` via the Skill tool with the track ID as args. Do NOT read the plan and start coding — the implement skill has its own protocol, CLI commands, and workflow.
+7. **Ask about implementation**: Use the AskUserQuestion **tool** (NOT a plain text question) to ask if the user wants to start implementation now:
+   - "Start implementation" → invoke Skill tool with `skill: "conductor:implement", args: "<TRACK_ID>"`
+   - "Just create track" → announce the track is ready and mention `/conductor:implement` as the next step when ready
 ```
 
 </protocol>
@@ -348,8 +348,8 @@ You MUST launch the `conductor:track-context-researcher` agent in this step. Do 
 - Do NOT interpret context clearing or the system reminder as a rejection or failure.
 - Do NOT ask what to do next, offer retry options, or request additional feedback.
 - **Read the CC plan file** at the path provided in the system reminder. The plan file contains the "Phase B — Execution Steps" section with all commands to run in order.
-- **Follow those Phase B steps exactly** — they include creating the branch, scaffolding, writing files, registering, committing, and invoking `conductor:implement` via the Skill tool.
-- Do NOT skip steps or implement the track yourself.
+- **Follow those Phase B steps exactly** — they include creating the branch, scaffolding, writing files, registering, committing, and optionally invoking `conductor:implement` via the Skill tool.
+- Do NOT skip steps 1-6 or implement the track yourself.
 </note>
 
 3. **If `ExitPlanMode` tool call itself errors** (tool not found, permission denied), instruct the user:
@@ -459,7 +459,32 @@ python ${CLAUDE_PLUGIN_ROOT}/scripts/conductor_cli.py --json newtrack register T
    git commit -m "<prefix>(conductor): Create track '<description>'"
    ```
 4. **Announce:** Inform user track is created.
-5. **Invoke implementation:** Call the Skill tool with `skill: "conductor:implement", args: "<TRACK_ID>"` to begin implementing the track. Do NOT attempt to implement the track yourself — the `conductor:implement` skill has its own protocol, CLI commands, and workflow that must be followed.
+
+</instructions>
+
+</phase>
+
+---
+
+<phase name="offer_implementation">
+
+## 2.5 OFFER IMPLEMENTATION
+
+<instructions>
+
+<note type="critical">
+You MUST use the AskUserQuestion tool here — do NOT ask a plain text question. This step is mandatory regardless of whether the commit step was skipped.
+</note>
+
+1. **Call AskUserQuestion** with:
+   - Header: "Next step"
+   - Question: "Would you like to start implementing this track now?"
+   - Options: `["Start implementation", "Just create track"]`
+   - multiSelect: `false`
+
+2. **Handle response:**
+   - **"Start implementation":** Call the Skill tool with `skill: "conductor:implement", args: "<TRACK_ID>"`. Do NOT attempt to implement the track yourself — the `conductor:implement` skill has its own protocol.
+   - **"Just create track":** Announce the track is ready and inform the user they can run `/conductor:implement` when they want to start.
 
 </instructions>
 

--- a/commands/newTrack.md
+++ b/commands/newTrack.md
@@ -335,7 +335,9 @@ You MUST launch the `conductor:track-context-researcher` agent in this step. Do 
 3. **If `ExitPlanMode` is unavailable or fails**, instruct the user:
     > "Please press `Shift+Tab` to exit Plan Mode. You can review the spec and plan content above before we proceed to create the files."
 
-4. **Wait for user approval** before proceeding to Phase B.
+<note type="critical">
+Once `ExitPlanMode` completes (or the user exits plan mode manually), the content is approved. Do NOT ask for additional confirmation, feedback, or approval. Proceed IMMEDIATELY to Phase B, Step 2.1.
+</note>
 
 </instructions>
 

--- a/commands/newTrack.md
+++ b/commands/newTrack.md
@@ -280,9 +280,7 @@ After setup verification passes, proceed to **Section 1.2**.
 3. **Compose `spec.md` content** (hold in context — do NOT write files yet):
     Include: Overview, Background, Functional Requirements, Non-Functional Requirements, Acceptance Criteria, Out of Scope
 
-4. **User Confirmation:** Present the composed spec and use Approval pattern (Approve/Suggest changes)
-    - **Approve:** Proceed to Section 1.5
-    - **Suggest changes:** Revise and present again
+4. **Present draft inline** for the user to see. Do NOT use a formal Approval prompt here — the spec will be formally reviewed together with the plan via ExitPlanMode in Step 1.7. If the user volunteers feedback at this point, incorporate it before proceeding.
 
 </instructions>
 
@@ -305,7 +303,7 @@ After setup verification passes, proceed to **Section 1.2**.
     - **CRITICAL:** Adhere to **Workflow** methodology (TDD structure)
     - **CRITICAL:** Append verification task to each phase: `- [ ] Task: Conductor - User Manual Verification '<Phase Name>' (Protocol in workflow.md)`
 
-3. **User Confirmation:** Present the composed plan and use Approval pattern (Approve/Suggest changes)
+3. **Present draft inline** for the user to see. Do NOT use a formal Approval prompt here — the plan will be formally reviewed together with the spec via ExitPlanMode in Step 1.7. If the user volunteers feedback at this point, incorporate it before proceeding.
 
 </instructions>
 
@@ -319,15 +317,17 @@ After setup verification passes, proceed to **Section 1.2**.
 
 <instructions>
 
+**This is the single formal approval gate for all composed content.**
+
 1. **Compose the CC plan file** using the format defined in `<protocol name="cc_plan_file">`, combining:
     - Track configuration (type, branch name)
-    - Approved spec content
-    - Approved plan content
+    - Composed spec content
+    - Composed plan content
     - Execution preview
 
 2. **Call `ExitPlanMode`** with the composed content as the plan.
-    - This presents the plan to the user for final review
-    - The user can press `Ctrl+G` to edit the plan before approving
+    - This presents the combined spec + plan to the user for review and approval
+    - The user can press `Ctrl+G` to edit the content before approving
     - The user approves by pressing `Enter` or continuing the conversation
 
 3. **If `ExitPlanMode` is unavailable or fails**, instruct the user:

--- a/commands/newTrack.md
+++ b/commands/newTrack.md
@@ -223,7 +223,7 @@ After setup verification passes, proceed to **Section 1.2**.
 
 <instructions>
 
-**Launch the `track-context-researcher` agent** to gather project context efficiently.
+**Launch the `conductor:track-context-researcher` agent** to gather project context efficiently.
 
 1. **Prepare input** for the agent:
     ```json
@@ -240,7 +240,7 @@ After setup verification passes, proceed to **Section 1.2**.
     ```
 
 2. **Launch agent** using the Agent tool with:
-    - `subagent_type`: `"track-context-researcher"`
+    - `subagent_type`: `"conductor:track-context-researcher"`
     - `prompt`: The JSON input above
     - `model`: `"haiku"` (cost-efficient for context gathering)
 

--- a/commands/newTrack.md
+++ b/commands/newTrack.md
@@ -47,9 +47,6 @@ The following CLI commands are used for write operations during track creation:
 # Generate track ID from description
 python ${CLAUDE_PLUGIN_ROOT}/scripts/conductor_cli.py --json newtrack generate-id "DESCRIPTION"
 
-# Scaffold track directory with template files
-python ${CLAUDE_PLUGIN_ROOT}/scripts/conductor_cli.py --json newtrack scaffold TRACK_ID --type TYPE --description "DESC"
-
 # Validate and enforce metadata.json for the track
 python ${CLAUDE_PLUGIN_ROOT}/scripts/conductor_cli.py --json newtrack register TRACK_ID --description "DESC"
 ```
@@ -61,8 +58,7 @@ Valid types: `feature` (default), `bugfix`, `refactor`, `docs`, `chore`
 ### Fallback Instructions
 
 1. **For `generate-id` failure:** Generate manually using format `shortname_YYYYMMDD`
-2. **For `scaffold` failure:** Create directory and files manually with Write tool
-3. **For `register` failure:** Edit `conductor/tracks/<track_id>/metadata.json` directly
+2. **For `register` failure:** Edit `conductor/tracks/<track_id>/metadata.json` directly
 
 </cli_reference>
 
@@ -138,14 +134,18 @@ After exiting plan mode, execute these steps in order. Use the Conductor CLI at 
 
 1. **Create git branch**: `git checkout -b <prefix>/<shortname>`
 2. **Generate track ID**: `python ${CLAUDE_PLUGIN_ROOT}/scripts/conductor_cli.py --json newtrack generate-id "<description>"`
-3. **Scaffold directory**: `python ${CLAUDE_PLUGIN_ROOT}/scripts/conductor_cli.py --json newtrack scaffold <TRACK_ID> --type <type> --description "<description>"`
-4. **Write spec.md**: Overwrite `conductor/tracks/<TRACK_ID>/spec.md` with the Specification content above
-5. **Write plan.md**: Overwrite `conductor/tracks/<TRACK_ID>/plan.md` with the Implementation Plan content above
-6. **Register track**: `python ${CLAUDE_PLUGIN_ROOT}/scripts/conductor_cli.py --json newtrack register <TRACK_ID> --description "<description>"`
-7. **Commit**: Stage with `git add conductor/tracks/<TRACK_ID>/metadata.json && git add conductor/tracks/<TRACK_ID>/*`, then commit with type-appropriate prefix
-8. **Start implementation**: Call the Skill tool with `skill: "conductor:implement"` — do NOT implement the track yourself
+3. **Create directory**: `mkdir -p conductor/tracks/<TRACK_ID>`
+4. **Write all track files** using the Write tool (no scaffold — write directly):
+   - `spec.md` — approved Specification content above
+   - `plan.md` — approved Implementation Plan content above
+   - `index.md` — track index linking to spec, plan, decisions, metadata
+   - `decisions.md` — empty ADR template
+   - `metadata.json` — `{"track_id":"<ID>","type":"<type>","status":"pending","description":"<desc>","created_at":"<ISO>","updated_at":"<ISO>"}`
+5. **Register track**: `python ${CLAUDE_PLUGIN_ROOT}/scripts/conductor_cli.py --json newtrack register <TRACK_ID> --description "<description>"`
+6. **Commit**: Stage with `git add conductor/tracks/<TRACK_ID>/metadata.json && git add conductor/tracks/<TRACK_ID>/*`, then commit with type-appropriate prefix
+7. **Start implementation**: Call the Skill tool with `skill: "conductor:implement", args: "<TRACK_ID>"` — do NOT implement the track yourself
 
-**CRITICAL**: Step 8 is mandatory. You MUST invoke `conductor:implement` via the Skill tool. Do NOT read the plan and start coding — the implement skill has its own protocol, CLI commands, and workflow.
+**CRITICAL**: Step 7 is mandatory. You MUST invoke `conductor:implement` via the Skill tool with the track ID as args. Do NOT read the plan and start coding — the implement skill has its own protocol, CLI commands, and workflow.
 ```
 
 </protocol>
@@ -389,7 +389,7 @@ Use the branch name decided in Step 1.2. The branch name and prefix were already
 
 <phase name="generate_and_scaffold">
 
-## 2.2 GENERATE TRACK ID AND SCAFFOLD
+## 2.2 GENERATE TRACK ID AND CREATE FILES
 
 <instructions>
 
@@ -398,29 +398,16 @@ Use the branch name decided in Step 1.2. The branch name and prefix were already
 | Step | Action | Fallback |
 |------|--------|----------|
 | 1. Generate ID | `python ${CLAUDE_PLUGIN_ROOT}/scripts/conductor_cli.py --json newtrack generate-id "DESC"` | Manual: `shortname_YYYYMMDD` |
-| 2. Scaffold | `python ${CLAUDE_PLUGIN_ROOT}/scripts/conductor_cli.py --json newtrack scaffold TRACK_ID --type TYPE --description "DESC"` | Create directory and files manually |
+| 2. Create directory | `mkdir -p conductor/tracks/<TRACK_ID>` | — |
 
-The scaffold command creates 5 template files. The next step will overwrite `spec.md` and `plan.md` with approved content.
+Then **Write all 5 track files directly** (no scaffold — avoids overwrite conflicts):
 
-</instructions>
-
-</phase>
-
----
-
-<phase name="write_spec_plan">
-
-## 2.3 WRITE SPEC AND PLAN
-
-<instructions>
-
-**Overwrite the scaffolded template files with the approved content from Phase A:**
-
-1. **Read back the approved content** from conversation context (composed in Steps 1.4 and 1.5)
-2. **Write `spec.md`**: Use the Write tool to overwrite `conductor/tracks/<track_id>/spec.md` with the approved spec content
-3. **Write `plan.md`**: Use the Write tool to overwrite `conductor/tracks/<track_id>/plan.md` with the approved plan content
-
-Only spec.md and plan.md need overwriting — index.md, metadata.json, and decisions.md from scaffold are correct as-is.
+1. **Read back the approved content** from conversation context (or from the CC plan file if context was cleared)
+2. **Write `spec.md`**: approved spec content
+3. **Write `plan.md`**: approved plan content
+4. **Write `index.md`**: track index with links to spec, plan, decisions, metadata
+5. **Write `decisions.md`**: empty ADR template (read from `templates/decisions.md` if it exists, otherwise minimal template)
+6. **Write `metadata.json`**: `{"track_id": "<ID>", "type": "<type>", "status": "pending", "description": "<desc>", "created_at": "<ISO>", "updated_at": "<ISO>"}`
 
 </instructions>
 
@@ -472,7 +459,7 @@ python ${CLAUDE_PLUGIN_ROOT}/scripts/conductor_cli.py --json newtrack register T
    git commit -m "<prefix>(conductor): Create track '<description>'"
    ```
 4. **Announce:** Inform user track is created.
-5. **Invoke implementation:** Call the Skill tool with `skill: "conductor:implement"` to begin implementing the track. Do NOT attempt to implement the track yourself — the `conductor:implement` skill has its own protocol, CLI commands, and workflow that must be followed.
+5. **Invoke implementation:** Call the Skill tool with `skill: "conductor:implement", args: "<TRACK_ID>"` to begin implementing the track. Do NOT attempt to implement the track yourself — the `conductor:implement` skill has its own protocol, CLI commands, and workflow that must be followed.
 
 </instructions>
 

--- a/commands/newTrack.md
+++ b/commands/newTrack.md
@@ -223,7 +223,9 @@ After setup verification passes, proceed to **Section 1.2**.
 
 <instructions>
 
-**Launch the `conductor:track-context-researcher` agent** to gather project context efficiently.
+<note type="critical">
+You MUST launch the `conductor:track-context-researcher` agent in this step. Do NOT skip it or read project files yourself — the agent offloads context gathering to a cheaper model and keeps the parent context clean.
+</note>
 
 1. **Prepare input** for the agent:
     ```json
@@ -249,7 +251,7 @@ After setup verification passes, proceed to **Section 1.2**.
     - Relevant file references in the spec
     - Pattern adherence in the plan
 
-4. **If agent fails or is unavailable**, fall back to reading project files directly:
+4. **Fallback (ONLY if the Agent tool call returns an error):** Read project files directly:
     - Read **Product Definition**, **Tech Stack**, **Workflow**, **Product Guidelines** via Universal File Resolution Protocol
     - Reference `conductor/docs/` and `conductor/product-guidelines.md` for established codebase patterns
 

--- a/commands/newTrack.md
+++ b/commands/newTrack.md
@@ -13,6 +13,7 @@ allowed-tools:
   - Agent
   - EnterPlanMode
   - ExitPlanMode
+  - Skill
 ---
 
 # Context
@@ -127,14 +128,24 @@ During Phase A, composed content is written to the CC plan file for user review.
 
 ---
 
-## Execution Preview
-When approved, the following actions will be taken:
-1. Create git branch `<prefix>/<shortname>`
-2. Generate track ID via CLI
-3. Scaffold track directory at `conductor/tracks/<track_id>/`
-4. Write spec.md and plan.md with the content above
-5. Register track via CLI
-6. Prompt for commit
+## Phase B — Execution Steps (follow in order after approval)
+
+After exiting plan mode, execute these steps in order. Use the Conductor CLI at `${CLAUDE_PLUGIN_ROOT}/scripts/conductor_cli.py`.
+
+1. **Create git branch**: `git checkout -b <prefix>/<shortname>`
+2. **Generate track ID**: `python ${CLAUDE_PLUGIN_ROOT}/scripts/conductor_cli.py --json newtrack generate-id "<description>"`
+3. **Create directory**: `mkdir -p conductor/tracks/<TRACK_ID>`
+4. **Write all track files** using the Write tool (no scaffold — write directly):
+   - `spec.md` — approved Specification content above
+   - `plan.md` — approved Implementation Plan content above
+   - `index.md` — track index linking to spec, plan, decisions, metadata
+   - `decisions.md` — empty ADR template
+   - `metadata.json` — `{"track_id":"<ID>","type":"<type>","status":"pending","description":"<desc>","created_at":"<ISO>","updated_at":"<ISO>"}`
+5. **Register track**: `python ${CLAUDE_PLUGIN_ROOT}/scripts/conductor_cli.py --json newtrack register <TRACK_ID> --description "<description>"`
+6. **Commit**: Stage with `git add conductor/tracks/<TRACK_ID>/metadata.json && git add conductor/tracks/<TRACK_ID>/*`, then commit with type-appropriate prefix
+7. **Start implementation**: Call the Skill tool with `skill: "conductor:implement", args: "<TRACK_ID>"` — do NOT implement the track yourself
+
+**CRITICAL**: Step 7 is mandatory. You MUST invoke `conductor:implement` via the Skill tool with the track ID as args. Do NOT read the plan and start coding — the implement skill has its own protocol, CLI commands, and workflow.
 ```
 
 </protocol>
@@ -169,7 +180,13 @@ When approved, the following actions will be taken:
 
 **PROTOCOL: Follow the Verify Setup Protocol in `protocols/verify-setup.md`.**
 
-This step only reads files (product.md, tech-stack.md, workflow.md) — fully compatible with plan mode.
+This step only reads files — fully compatible with plan mode.
+
+**Explicit file resolution steps:**
+1. Read `conductor/index.md` to find the actual paths for Product Definition, Tech Stack, and Workflow
+2. If `conductor/index.md` doesn't exist, use default paths: `conductor/product.md`, `conductor/tech-stack.md`, `conductor/workflow.md`
+3. Verify each file exists. If any are missing, HALT and tell the user to run `/conductor:setup`
+4. Store the resolved paths — they will be passed to the context research agent in Step 1.3
 
 After setup verification passes, proceed to **Section 1.2**.
 
@@ -186,8 +203,8 @@ After setup verification passes, proceed to **Section 1.2**.
 <instructions>
 
 1. **Get Track Description:**
-    * **If `{{args}}` contains a description:** Use its content.
-    * **Else If it is empty:** Use AskUserQuestion to ask:
+    * **If `{{args}}` contains a description:** Use the content of `{{args}}`.
+    * **If `{{args}}` is empty:** Use AskUserQuestion to ask:
         > "Please provide a brief description of the track (feature, bug fix, chore, etc.) you wish to start."
         Await the user's response and use it as the track description.
 
@@ -219,7 +236,9 @@ After setup verification passes, proceed to **Section 1.2**.
 
 <instructions>
 
-**Launch the `track-context-researcher` agent** to gather project context efficiently.
+<note type="critical">
+You MUST launch the `conductor:track-context-researcher` agent in this step. Do NOT skip it or read project files yourself — the agent offloads context gathering to a cheaper model and keeps the parent context clean.
+</note>
 
 1. **Prepare input** for the agent:
     ```json
@@ -236,7 +255,7 @@ After setup verification passes, proceed to **Section 1.2**.
     ```
 
 2. **Launch agent** using the Agent tool with:
-    - `subagent_type`: `"track-context-researcher"`
+    - `subagent_type`: `"conductor:track-context-researcher"`
     - `prompt`: The JSON input above
     - `model`: `"haiku"` (cost-efficient for context gathering)
 
@@ -245,7 +264,7 @@ After setup verification passes, proceed to **Section 1.2**.
     - Relevant file references in the spec
     - Pattern adherence in the plan
 
-4. **If agent fails or is unavailable**, fall back to reading project files directly:
+4. **Fallback (ONLY if the Agent tool call returns an error):** Read project files directly:
     - Read **Product Definition**, **Tech Stack**, **Workflow**, **Product Guidelines** via Universal File Resolution Protocol
     - Reference `conductor/docs/` and `conductor/product-guidelines.md` for established codebase patterns
 
@@ -276,9 +295,7 @@ After setup verification passes, proceed to **Section 1.2**.
 3. **Compose `spec.md` content** (hold in context — do NOT write files yet):
     Include: Overview, Background, Functional Requirements, Non-Functional Requirements, Acceptance Criteria, Out of Scope
 
-4. **User Confirmation:** Present the composed spec and use Approval pattern (Approve/Suggest changes)
-    - **Approve:** Proceed to Section 1.5
-    - **Suggest changes:** Revise and present again
+4. **Present draft inline** for the user to see. Do NOT use a formal Approval prompt here — the spec will be formally reviewed together with the plan via ExitPlanMode in Step 1.6. If the user volunteers feedback at this point, incorporate it before proceeding.
 
 </instructions>
 
@@ -301,7 +318,7 @@ After setup verification passes, proceed to **Section 1.2**.
     - **CRITICAL:** Adhere to **Workflow** methodology (TDD structure)
     - **CRITICAL:** Append verification task to each phase: `- [ ] Task: Conductor - User Manual Verification '<Phase Name>' (Protocol in workflow.md)`
 
-3. **User Confirmation:** Present the composed plan and use Approval pattern (Approve/Suggest changes)
+3. **Present draft inline** for the user to see. Do NOT use a formal Approval prompt here — the plan will be formally reviewed together with the spec via ExitPlanMode in Step 1.6. If the user volunteers feedback at this point, incorporate it before proceeding.
 
 </instructions>
 
@@ -311,25 +328,33 @@ After setup verification passes, proceed to **Section 1.2**.
 
 <phase name="write_plan_file">
 
-## 1.7 WRITE TO CC PLAN FILE AND EXIT PLAN MODE
+## 1.6 WRITE TO CC PLAN FILE AND EXIT PLAN MODE
 
 <instructions>
 
+**This is the single formal approval gate for all composed content.**
+
 1. **Compose the CC plan file** using the format defined in `<protocol name="cc_plan_file">`, combining:
     - Track configuration (type, branch name)
-    - Approved spec content
-    - Approved plan content
+    - Composed spec content
+    - Composed plan content
     - Execution preview
 
 2. **Call `ExitPlanMode`** with the composed content as the plan.
-    - This presents the plan to the user for final review
-    - The user can press `Ctrl+G` to edit the plan before approving
-    - The user approves by pressing `Enter` or continuing the conversation
 
-3. **If `ExitPlanMode` is unavailable or fails**, instruct the user:
-    > "Please press `Shift+Tab` to exit Plan Mode. You can review the spec and plan content above before we proceed to create the files."
+<note type="critical">
+**How to interpret the ExitPlanMode result:**
+- After calling `ExitPlanMode`, the system will clear prior context and return a system reminder containing "Exited Plan Mode". This is **SUCCESS** — the user approved the plan.
+- Do NOT interpret context clearing or the system reminder as a rejection or failure.
+- Do NOT ask what to do next, offer retry options, or request additional feedback.
+- **Read the CC plan file** at the path provided in the system reminder. The plan file contains the "Phase B — Execution Steps" section with all commands to run in order.
+- **Follow those Phase B steps exactly** — they include creating the branch, scaffolding, writing files, registering, committing, and invoking `conductor:implement` via the Skill tool.
+- Do NOT skip steps or implement the track yourself.
+</note>
 
-4. **Wait for user approval** before proceeding to Phase B.
+3. **If `ExitPlanMode` tool call itself errors** (tool not found, permission denied), instruct the user:
+    > "Please press `Shift+Tab` to exit Plan Mode, then tell me to continue."
+    When the user confirms, proceed immediately to Phase B.
 
 </instructions>
 
@@ -364,7 +389,7 @@ Use the branch name decided in Step 1.2. The branch name and prefix were already
 
 <phase name="generate_and_scaffold">
 
-## 2.2 GENERATE TRACK ID AND SCAFFOLD
+## 2.2 GENERATE TRACK ID AND CREATE FILES
 
 <instructions>
 
@@ -373,29 +398,16 @@ Use the branch name decided in Step 1.2. The branch name and prefix were already
 | Step | Action | Fallback |
 |------|--------|----------|
 | 1. Generate ID | `python ${CLAUDE_PLUGIN_ROOT}/scripts/conductor_cli.py --json newtrack generate-id "DESC"` | Manual: `shortname_YYYYMMDD` |
-| 2. Scaffold | `python ${CLAUDE_PLUGIN_ROOT}/scripts/conductor_cli.py --json newtrack scaffold TRACK_ID --type TYPE --description "DESC"` | Create directory and files manually |
+| 2. Create directory | `mkdir -p conductor/tracks/<TRACK_ID>` | — |
 
-The scaffold command creates 5 template files. The next step will overwrite `spec.md` and `plan.md` with approved content.
+Then **Write all 5 track files directly** (no scaffold — avoids overwrite conflicts):
 
-</instructions>
-
-</phase>
-
----
-
-<phase name="write_spec_plan">
-
-## 2.3 WRITE SPEC AND PLAN
-
-<instructions>
-
-**Overwrite the scaffolded template files with the approved content from Phase A:**
-
-1. **Read back the approved content** from conversation context (composed in Steps 1.4 and 1.5)
-2. **Write `spec.md`**: Use the Write tool to overwrite `conductor/tracks/<track_id>/spec.md` with the approved spec content
-3. **Write `plan.md`**: Use the Write tool to overwrite `conductor/tracks/<track_id>/plan.md` with the approved plan content
-
-Only spec.md and plan.md need overwriting — index.md, metadata.json, and decisions.md from scaffold are correct as-is.
+1. **Read back the approved content** from conversation context (or from the CC plan file if context was cleared)
+2. **Write `spec.md`**: approved spec content
+3. **Write `plan.md`**: approved plan content
+4. **Write `index.md`**: track index with links to spec, plan, decisions, metadata
+5. **Write `decisions.md`**: empty ADR template (read from `templates/decisions.md` if it exists, otherwise minimal template)
+6. **Write `metadata.json`**: `{"track_id": "<ID>", "type": "<type>", "status": "pending", "description": "<desc>", "created_at": "<ISO>", "updated_at": "<ISO>"}`
 
 </instructions>
 
@@ -405,7 +417,7 @@ Only spec.md and plan.md need overwriting — index.md, metadata.json, and decis
 
 <phase name="register">
 
-## 2.4 REGISTER TRACK
+## 2.3 REGISTER TRACK
 
 <instructions>
 
@@ -423,7 +435,7 @@ python ${CLAUDE_PLUGIN_ROOT}/scripts/conductor_cli.py --json newtrack register T
 
 <phase name="commit">
 
-## 2.5 COMMIT AND FINALIZE
+## 2.4 COMMIT AND FINALIZE
 
 <instructions>
 
@@ -446,7 +458,8 @@ python ${CLAUDE_PLUGIN_ROOT}/scripts/conductor_cli.py --json newtrack register T
    ```bash
    git commit -m "<prefix>(conductor): Create track '<description>'"
    ```
-4. **Announce:** Inform user track is created. Next step: `/conductor:implement`
+4. **Announce:** Inform user track is created.
+5. **Invoke implementation:** Call the Skill tool with `skill: "conductor:implement", args: "<TRACK_ID>"` to begin implementing the track. Do NOT attempt to implement the track yourself — the `conductor:implement` skill has its own protocol, CLI commands, and workflow that must be followed.
 
 </instructions>
 

--- a/commands/newTrack.md
+++ b/commands/newTrack.md
@@ -9,6 +9,10 @@ allowed-tools:
   - Bash
   - Glob
   - Grep
+  - AskUserQuestion
+  - Agent
+  - EnterPlanMode
+  - ExitPlanMode
 ---
 
 # Context
@@ -19,6 +23,10 @@ allowed-tools:
 
 ## 1.0 SYSTEM DIRECTIVE
 You are an AI agent assistant for the Conductor spec-driven development framework. Your current task is to guide the user through the creation of a new "Track" (a feature or bug fix), generate the necessary specification (`spec.md`) and plan (`plan.md`) files, and organize them within a dedicated track directory.
+
+This command uses a **two-phase workflow** powered by Claude Code's Plan Mode:
+- **Phase A (Plan Mode):** Research, compose spec + plan content in read-only mode, write to CC plan file for review
+- **Phase B (Normal Mode):** After user approval, create branch, scaffold directory, write files, register, commit
 
 <note type="critical">
 You must validate the success of every tool call. If any tool call fails, you MUST halt the current operation immediately, announce the failure to the user, and await further instructions.
@@ -38,6 +46,9 @@ The following CLI commands are used for write operations during track creation:
 # Generate track ID from description
 python ${CLAUDE_PLUGIN_ROOT}/scripts/conductor_cli.py --json newtrack generate-id "DESCRIPTION"
 
+# Scaffold track directory with template files
+python ${CLAUDE_PLUGIN_ROOT}/scripts/conductor_cli.py --json newtrack scaffold TRACK_ID --type TYPE --description "DESC"
+
 # Validate and enforce metadata.json for the track
 python ${CLAUDE_PLUGIN_ROOT}/scripts/conductor_cli.py --json newtrack register TRACK_ID --description "DESC"
 ```
@@ -49,7 +60,8 @@ Valid types: `feature` (default), `bugfix`, `refactor`, `docs`, `chore`
 ### Fallback Instructions
 
 1. **For `generate-id` failure:** Generate manually using format `shortname_YYYYMMDD`
-2. **For `register` failure:** Edit `conductor/tracks/<track_id>/metadata.json` directly
+2. **For `scaffold` failure:** Create directory and files manually with Write tool
+3. **For `register` failure:** Edit `conductor/tracks/<track_id>/metadata.json` directly
 
 </cli_reference>
 
@@ -92,6 +104,67 @@ When user selects "Auto-generate": stop asking questions, use context to infer r
 
 ---
 
+<protocol name="cc_plan_file">
+
+## CC Plan File Format
+
+During Phase A, composed content is written to the CC plan file for user review. Use this exact structure:
+
+```markdown
+# New Track: <description>
+
+## Track Configuration
+- **Type**: <feature|bugfix|refactor|docs|chore>
+- **Branch**: <prefix>/<shortname>
+
+---
+
+## Specification
+
+<full spec.md content — Overview, Background, Functional Requirements, Non-Functional Requirements, Acceptance Criteria, Out of Scope>
+
+---
+
+## Implementation Plan
+
+<full plan.md content — Phases → Tasks → Sub-tasks with [ ] markers, verification tasks per phase>
+
+---
+
+## Execution Preview
+When approved, the following actions will be taken:
+1. Create git branch `<prefix>/<shortname>`
+2. Generate track ID via CLI
+3. Scaffold track directory at `conductor/tracks/<track_id>/`
+4. Write spec.md and plan.md with the content above
+5. Register track via CLI
+6. Prompt for commit
+```
+
+</protocol>
+
+---
+
+# PHASE A — PLAN MODE (read-only, system-enforced)
+
+<phase name="enter_plan_mode">
+
+## 1.0 ENTER PLAN MODE
+
+<instructions>
+
+**Call `EnterPlanMode` to activate read-only mode.**
+
+- If already in plan mode, skip this step
+- If `EnterPlanMode` is unavailable or fails, instruct the user: "Please press `Shift+Tab` to enter Plan Mode, then re-invoke the command."
+- Do NOT proceed to Phase A steps until plan mode is active
+
+</instructions>
+
+</phase>
+
+---
+
 <phase name="setup_check">
 
 ## 1.1 SETUP CHECK
@@ -100,7 +173,9 @@ When user selects "Auto-generate": stop asking questions, use context to infer r
 
 **PROTOCOL: Follow the Verify Setup Protocol in `protocols/verify-setup.md`.**
 
-After setup verification passes, proceed to **Section 1.2 GIT ISOLATION SETUP**.
+This step only reads files (product.md, tech-stack.md, workflow.md) — fully compatible with plan mode.
+
+After setup verification passes, proceed to **Section 1.2**.
 
 </instructions>
 
@@ -108,111 +183,274 @@ After setup verification passes, proceed to **Section 1.2 GIT ISOLATION SETUP**.
 
 ---
 
-<phase name="git_isolation">
+<phase name="get_description">
 
-## 1.2 GIT ISOLATION SETUP
+## 1.2 GET TRACK DESCRIPTION AND DETERMINE TYPE
+
+<instructions>
+
+1. **Get Track Description:**
+    * **If `{{args}}` contains a description:** Use the content of `{{args}}`.
+    * **If `{{args}}` is empty:** Use AskUserQuestion to ask:
+        > "Please provide a brief description of the track (feature, bug fix, chore, etc.) you wish to start."
+        Await the user's response and use it as the track description.
+
+2. **Infer Track Type:** Analyze the description to determine the track type. Do NOT ask the user to classify it. Use the valid types defined in `<cli_reference>`.
+
+3. **Decide Branch Name:** (for use in Phase B — do NOT create the branch yet)
+    - Extract shortname from the track description (3-4 key words, hyphen-separated, lowercase)
+    - Map track type to branch prefix:
+
+    | Track Type | Branch Prefix |
+    |------------|---------------|
+    | feature    | feature/      |
+    | bugfix     | fix/          |
+    | refactor   | refactor/     |
+    | docs       | docs/         |
+    | chore      | chore/        |
+
+    - Store the decided branch name (e.g., `feature/my-new-feature`) for Phase B
+
+</instructions>
+
+</phase>
+
+---
+
+<phase name="context_research">
+
+## 1.3 CONTEXT RESEARCH VIA SUBAGENT
+
+<instructions>
+
+**Launch the `track-context-researcher` agent** to gather project context efficiently.
+
+1. **Prepare input** for the agent:
+    ```json
+    {
+      "description": "<track description>",
+      "type": "<inferred track type>",
+      "project_files": {
+        "product_definition": "<resolved path to product.md>",
+        "tech_stack": "<resolved path to tech-stack.md>",
+        "workflow": "<resolved path to workflow.md>",
+        "product_guidelines": "<resolved path to product-guidelines.md>"
+      }
+    }
+    ```
+
+2. **Launch agent** using the Agent tool with:
+    - `subagent_type`: `"track-context-researcher"`
+    - `prompt`: The JSON input above
+    - `model`: `"haiku"` (cost-efficient for context gathering)
+
+3. **Parse the agent's JSON response** and use it to inform:
+    - Context-aware questions in Step 1.4
+    - Relevant file references in the spec
+    - Pattern adherence in the plan
+
+4. **If agent fails or is unavailable**, fall back to reading project files directly:
+    - Read **Product Definition**, **Tech Stack**, **Workflow**, **Product Guidelines** via Universal File Resolution Protocol
+    - Reference `conductor/docs/` and `conductor/product-guidelines.md` for established codebase patterns
+
+</instructions>
+
+</phase>
+
+---
+
+<phase name="spec_generation">
+
+## 1.4 INTERACTIVE SPECIFICATION GENERATION
+
+<instructions>
+
+**Pattern Examples:** See the patterns documented in `<protocol name="askuserquestion">` and `templates/askuserquestion-patterns.md` for full JSON examples.
+
+1. **Announce Goal:** "I'll now guide you through questions to build a specification for this track."
+
+2. **Questioning Phase:**
+    - Ask questions **sequentially** using AskUserQuestion tool, following the constraints in `<protocol name="askuserquestion">`
+    - Incorporate suggested questions from the context research agent (Step 1.3) where relevant
+    - Refer to **Product Definition**, **Tech Stack** for context-aware questions
+    - Always include "Auto-generate" as the last option
+    - **FEATURE:** Ask 3-5 questions (interaction type, capabilities, data flow)
+    - **BUG/OTHER:** Ask 2-3 questions (reproduction steps, success criteria)
+
+3. **Compose `spec.md` content** (hold in context — do NOT write files yet):
+    Include: Overview, Background, Functional Requirements, Non-Functional Requirements, Acceptance Criteria, Out of Scope
+
+4. **User Confirmation:** Present the composed spec and use Approval pattern (Approve/Suggest changes)
+    - **Approve:** Proceed to Section 1.5
+    - **Suggest changes:** Revise and present again
+
+</instructions>
+
+</phase>
+
+---
+
+<phase name="plan_generation">
+
+## 1.5 INTERACTIVE PLAN GENERATION
+
+<instructions>
+
+1. **Announce Goal:** "Now I will create an implementation plan based on the specification."
+
+2. **Compose `plan.md` content** (hold in context — do NOT write files yet):
+    - Use confirmed spec content, **Workflow** file, and context research results
+    - Generate hierarchical structure: Phases → Tasks → Sub-tasks
+    - Include status markers `[ ]` for every task
+    - **CRITICAL:** Adhere to **Workflow** methodology (TDD structure)
+    - **CRITICAL:** Append verification task to each phase: `- [ ] Task: Conductor - User Manual Verification '<Phase Name>' (Protocol in workflow.md)`
+
+3. **User Confirmation:** Present the composed plan and use Approval pattern (Approve/Suggest changes)
+
+</instructions>
+
+</phase>
+
+---
+
+<phase name="write_plan_file">
+
+## 1.7 WRITE TO CC PLAN FILE AND EXIT PLAN MODE
+
+<instructions>
+
+1. **Compose the CC plan file** using the format defined in `<protocol name="cc_plan_file">`, combining:
+    - Track configuration (type, branch name)
+    - Approved spec content
+    - Approved plan content
+    - Execution preview
+
+2. **Call `ExitPlanMode`** with the composed content as the plan.
+    - This presents the plan to the user for final review
+    - The user can press `Ctrl+G` to edit the plan before approving
+    - The user approves by pressing `Enter` or continuing the conversation
+
+3. **If `ExitPlanMode` is unavailable or fails**, instruct the user:
+    > "Please press `Shift+Tab` to exit Plan Mode. You can review the spec and plan content above before we proceed to create the files."
+
+4. **Wait for user approval** before proceeding to Phase B.
+
+</instructions>
+
+</phase>
+
+---
+
+# PHASE B — NORMAL MODE (writes enabled, after user approval)
+
+<phase name="create_branch">
+
+## 2.1 CREATE GIT BRANCH
 
 <instructions>
 
 **PROTOCOL: Follow the Git Isolation Protocol in `protocols/git-isolation.md`.**
 
-This section ensures track work is properly isolated from the main codebase. Execute the Git Isolation Protocol to create or switch to a dedicated git branch before track creation begins.
+Use the branch name decided in Step 1.2. The branch name and prefix were already determined during Phase A — now execute the creation:
 
-</instructions>
+1. **Create and switch to the branch:** `git checkout -b <branch_name>`
+2. If the branch already exists, ask the user whether to switch to it or choose a different name
 
 <note>
-**Note for newTrack:** Since the `track_id` does not exist yet, use the track description to generate the branch name:
-1. Extract shortname from the track description (3-4 key words, hyphen-separated, lowercase)
-2. Use the inferred track type to determine the branch prefix (using track types defined in `<cli_reference>`)
-3. Present branch options to the user following the protocol
+**Note for newTrack:** Since the `track_id` does not exist yet, the branch name was derived from the track description in Step 1.2.
 </note>
 
-After completing the protocol, proceed to **Section 2.0 NEW TRACK INITIALIZATION**.
+</instructions>
 
 </phase>
 
 ---
 
-<phase name="initialization">
+<phase name="generate_and_scaffold">
 
-## 2.0 NEW TRACK INITIALIZATION
-**PROTOCOL: Follow this sequence precisely.**
+## 2.2 GENERATE TRACK ID AND SCAFFOLD
 
-<instructions name="get_description">
+<instructions>
 
-### 2.1 Get Track Description and Determine Type
-
-1.  **Load Project Context:** Read and understand the content of the project documents (**Product Definition**, **Tech Stack**, etc.) resolved via the **Universal File Resolution Protocol**.
-2.  **Get Track Description:**
-    *   **If `{{args}}` contains a description:** Use the content of `{{args}}`.
-    *   **If `{{args}}` is empty:** Ask the user:
-        > "Please provide a brief description of the track (feature, bug fix, chore, etc.) you wish to start."
-        Await the user's response and use it as the track description.
-3.  **Infer Track Type:** Analyze the description to determine if it is a "Feature" or "Something Else" (e.g., Bug, Chore, Refactor). Do NOT ask the user to classify it. Use the valid types defined in `<cli_reference>`.
-4.  **Use Existing Pattern Documentation:** Reference `conductor/docs/` and `conductor/product-guidelines.md` for established codebase patterns (naming, architecture, testing). These were generated during setup and should inform spec generation.
-
-</instructions>
-
-<instructions name="spec_generation">
-
-### 2.2 Interactive Specification Generation (`spec.md`)
-
-**Pattern Examples:** See the patterns documented in `<protocol name="askuserquestion">` and `templates/askuserquestion-patterns.md` for full JSON examples.
-
-1.  **Announce Goal:** "I'll now guide you through questions to build a specification for this track."
-
-2.  **Questioning Phase:**
-    -   Ask questions **sequentially** using AskUserQuestion tool, following the constraints in `<protocol name="askuserquestion">`
-    -   Refer to **Product Definition**, **Tech Stack** for context-aware questions
-    -   Always include "Auto-generate" as the last option
-    -   **FEATURE:** Ask 3-5 questions (interaction type, capabilities, data flow)
-    -   **BUG/OTHER:** Ask 2-3 questions (reproduction steps, success criteria)
-
-3.  **Draft `spec.md`:** Include Overview, Functional Requirements, Non-Functional Requirements, Acceptance Criteria, Out of Scope.
-
-4.  **User Confirmation:** Present draft and use Approval pattern (Approve/Suggest changes)
-    -   **Approve:** Proceed to Section 2.3
-    -   **Suggest changes:** Revise and present again
-
-</instructions>
-
-<instructions name="plan_generation">
-
-### 2.3 Interactive Plan Generation (`plan.md`)
-
-1.  **Announce Goal:** "Now I will create an implementation plan based on the specification."
-
-2.  **Generate Plan:**
-    -   Read confirmed `spec.md` and **Workflow** file
-    -   Generate hierarchical structure: Phases → Tasks → Sub-tasks
-    -   Include status markers `[ ]` for every task
-    -   **CRITICAL:** Adhere to **Workflow** methodology (TDD structure)
-    -   **CRITICAL:** Append verification task to each phase: `- [ ] Task: Conductor - User Manual Verification '<Phase Name>' (Protocol in workflow.md)`
-
-3.  **User Confirmation:** Present draft and use Approval pattern (Approve/Suggest changes)
-
-</instructions>
-
-<instructions name="create_register">
-
-### 2.4 Create and Register Track
-
-**PROTOCOL: Use the CLI commands defined in `<cli_reference>` for ID generation and registration. Use Write tool directly for file creation.**
+**PROTOCOL: Use the CLI commands defined in `<cli_reference>`.**
 
 | Step | Action | Fallback |
 |------|--------|----------|
 | 1. Generate ID | `python ${CLAUDE_PLUGIN_ROOT}/scripts/conductor_cli.py --json newtrack generate-id "DESC"` | Manual: `shortname_YYYYMMDD` |
-| 2. Create Directory | `mkdir -p conductor/tracks/<track_id>` | - |
-| 3. Create Files | Use Write tool to create each file directly (index.md, metadata.json, spec.md, plan.md, decisions.md) with the confirmed spec and plan content | - |
-| 4. Register | `python ${CLAUDE_PLUGIN_ROOT}/scripts/conductor_cli.py --json newtrack register ID --description "DESC"` | Edit `conductor/tracks/<track_id>/metadata.json` directly |
+| 2. Scaffold | `python ${CLAUDE_PLUGIN_ROOT}/scripts/conductor_cli.py --json newtrack scaffold TRACK_ID --type TYPE --description "DESC"` | Create directory and files manually |
 
-**Files created:** `conductor/tracks/<track_id>/` containing: index.md, metadata.json, spec.md, plan.md, decisions.md
+The scaffold command creates 5 template files. The next step will overwrite `spec.md` and `plan.md` with approved content.
 
-#### Commit and Finalize
+</instructions>
 
-5.  **Confirm Commit:** Use AskUserQuestion with Commit pattern (Commit now/Skip commit), following constraints in `<protocol name="askuserquestion">`
-6.  **Commit (if confirmed):** `git add conductor/tracks/<track_id>/* && git commit -m "conductor(track): Create track '<description>'"`
-7.  **Announce:** Inform user track is created. Next step: `/conductor:implement`
+</phase>
+
+---
+
+<phase name="write_spec_plan">
+
+## 2.3 WRITE SPEC AND PLAN
+
+<instructions>
+
+**Overwrite the scaffolded template files with the approved content from Phase A:**
+
+1. **Read back the approved content** from conversation context (composed in Steps 1.4 and 1.5)
+2. **Write `spec.md`**: Use the Write tool to overwrite `conductor/tracks/<track_id>/spec.md` with the approved spec content
+3. **Write `plan.md`**: Use the Write tool to overwrite `conductor/tracks/<track_id>/plan.md` with the approved plan content
+
+Only spec.md and plan.md need overwriting — index.md, metadata.json, and decisions.md from scaffold are correct as-is.
+
+</instructions>
+
+</phase>
+
+---
+
+<phase name="register">
+
+## 2.4 REGISTER TRACK
+
+<instructions>
+
+```bash
+python ${CLAUDE_PLUGIN_ROOT}/scripts/conductor_cli.py --json newtrack register TRACK_ID --description "DESC"
+```
+
+**Fallback:** Edit `conductor/tracks/<track_id>/metadata.json` directly if CLI fails.
+
+</instructions>
+
+</phase>
+
+---
+
+<phase name="commit">
+
+## 2.5 COMMIT AND FINALIZE
+
+<instructions>
+
+1. **Confirm Commit:** Use AskUserQuestion with Commit pattern (Commit now/Skip commit), following constraints in `<protocol name="askuserquestion">`
+2. **Stage metadata.json first** (per project feedback — metadata must be staged before committing):
+   ```bash
+   git add conductor/tracks/<track_id>/metadata.json
+   git add conductor/tracks/<track_id>/*
+   ```
+3. **Commit (if confirmed):** Use commit type matching the track type:
+
+   | Track Type | Commit Prefix |
+   |------------|---------------|
+   | feature    | feat          |
+   | bugfix     | fix           |
+   | refactor   | refactor      |
+   | docs       | docs          |
+   | chore      | chore         |
+
+   ```bash
+   git commit -m "<prefix>(conductor): Create track '<description>'"
+   ```
+4. **Announce:** Inform user track is created. Next step: `/conductor:implement`
 
 </instructions>
 


### PR DESCRIPTION
## Summary

- Restructure `newTrack` command into two phases: **Plan Mode** (read-only research, spec/plan composition, CC plan file as review surface) and **Normal Mode** (branch creation, scaffold via CLI, file writes, registration, commit)
- Add `track-context-researcher` agent (haiku model) for cost-efficient project context gathering during spec generation
- Leverage CLI `scaffold` subcommand in Phase B to reduce Write calls from 5 to 2

## Test plan

- [x] Invoke `/conductor:newTrack "test feature"` and verify `EnterPlanMode` is called
- [x] Verify no files are written during Phase A (setup check, questioning, composition are all read-only)
- [x] Verify CC plan file contains well-structured spec + plan content at `ExitPlanMode`
- [x] After approval, verify Phase B creates git branch, scaffolds directory, writes spec/plan, registers track
- [x] Verify commit includes all expected files with correct metadata.json staging order
- [x] Test fallback paths: `EnterPlanMode` unavailable, agent failure, CLI failure