### PR TITLE
refactor: Enforce AskUserQuestion globally via patterns template

### DIFF
--- a/commands/newTrack.md
+++ b/commands/newTrack.md
@@ -143,7 +143,7 @@ After exiting plan mode, execute these steps in order. Use the Conductor CLI at 
    - `metadata.json` — `{"track_id":"<ID>","type":"<type>","status":"pending","description":"<desc>","created_at":"<ISO>","updated_at":"<ISO>"}`
 5. **Register track**: `python ${CLAUDE_PLUGIN_ROOT}/scripts/conductor_cli.py --json newtrack register <TRACK_ID> --description "<description>"`
 6. **Commit**: Stage with `git add conductor/tracks/<TRACK_ID>/metadata.json && git add conductor/tracks/<TRACK_ID>/*`, then commit with type-appropriate prefix
-7. **Ask about implementation**: Use the AskUserQuestion **tool** (NOT a plain text question) to ask if the user wants to start implementation now:
+7. **Ask about implementation**: Use the AskUserQuestion tool to ask if the user wants to start implementation now:
    - "Start implementation" → invoke Skill tool with `skill: "conductor:implement", args: "<TRACK_ID> --warm-start"`
    - "Just create track" → announce the track is ready and mention `/conductor:implement` as the next step when ready
 ```

--- a/commands/newTrack.md
+++ b/commands/newTrack.md
@@ -472,10 +472,6 @@ python ${CLAUDE_PLUGIN_ROOT}/scripts/conductor_cli.py --json newtrack register T
 
 <instructions>
 
-<note type="critical">
-You MUST use the AskUserQuestion tool here — do NOT ask a plain text question. This step is mandatory regardless of whether the commit step was skipped.
-</note>
-
 1. **Call AskUserQuestion** with:
    - Header: "Next step"
    - Question: "Would you like to start implementing this track now?"

--- a/conductor/tracks/enforce-askuserquestion-all-questions_20260322/decisions.md
+++ b/conductor/tracks/enforce-askuserquestion-all-questions_20260322/decisions.md
@@ -1,0 +1,43 @@
+# Decisions Log
+
+> Architecture Decision Records (ADRs) for this track. Each decision documents the context, choice made, and consequences.
+
+## About This File
+
+This file captures significant technical and architectural decisions made during implementation. Not every choice needs to be documented—only those that:
+
+- Involve tradeoffs between alternatives
+- Have long-term implications
+- Would benefit future maintainers understanding "why"
+- Deviate from common patterns or conventions
+
+## Decision Format
+
+Each decision follows the ADR format:
+
+```markdown
+### ADR-###: [Decision Title]
+
+**Date:** YYYY-MM-DD
+**Status:** Proposed | Accepted | Deprecated | Superseded
+
+#### Context
+[Facts and circumstances that led to this decision point]
+
+#### Decision
+[The choice that was made]
+
+#### Consequences
+[Both positive and negative outcomes of this decision]
+
+#### Alternatives Considered (Optional)
+[Other options evaluated with brief pros/cons]
+```
+
+---
+
+## Decisions
+
+<!-- Decisions are added below in chronological order -->
+
+_No decisions recorded yet._

--- a/conductor/tracks/enforce-askuserquestion-all-questions_20260322/index.md
+++ b/conductor/tracks/enforce-askuserquestion-all-questions_20260322/index.md
@@ -1,0 +1,10 @@
+# Track: Enforce AskUserQuestion for all questions in newTrack.md
+
+> Global enforcement of AskUserQuestion tool for all interactive prompts across Conductor commands.
+
+## Documents
+
+- [Specification](./spec.md) - Track requirements and acceptance criteria
+- [Implementation Plan](./plan.md) - Phased implementation tasks
+- [Decisions](./decisions.md) - Architecture Decision Records
+- [Metadata](./metadata.json) - Track status and configuration

--- a/conductor/tracks/enforce-askuserquestion-all-questions_20260322/metadata.json
+++ b/conductor/tracks/enforce-askuserquestion-all-questions_20260322/metadata.json
@@ -1,0 +1,8 @@
+{
+  "track_id": "enforce-askuserquestion-all-questions_20260322",
+  "type": "refactor",
+  "status": "pending",
+  "description": "Enforce AskUserQuestion for all questions in newTrack.md",
+  "created_at": "2026-03-22T00:00:00Z",
+  "updated_at": "2026-03-22T00:00:00Z"
+}

--- a/conductor/tracks/enforce-askuserquestion-all-questions_20260322/metadata.json
+++ b/conductor/tracks/enforce-askuserquestion-all-questions_20260322/metadata.json
@@ -1,8 +1,8 @@
 {
   "track_id": "enforce-askuserquestion-all-questions_20260322",
   "type": "refactor",
-  "status": "pending",
+  "status": "completed",
   "description": "Enforce AskUserQuestion for all questions in newTrack.md",
   "created_at": "2026-03-22T00:00:00Z",
-  "updated_at": "2026-03-22T00:00:00Z"
+  "updated_at": "2026-03-23T22:14:03.437854Z"
 }

--- a/conductor/tracks/enforce-askuserquestion-all-questions_20260322/plan.md
+++ b/conductor/tracks/enforce-askuserquestion-all-questions_20260322/plan.md
@@ -1,0 +1,11 @@
+## Implementation Plan
+
+### Phase 1: Global enforcement refactor
+
+- [ ] Task 1.1: Add enforcement section to `templates/askuserquestion-patterns.md` — add a `## Mandatory Usage` section near the top (after the Key Rules section) with clear directive that AskUserQuestion is mandatory for all interactive prompts, no exceptions
+- [ ] Task 1.2: Remove the `<note type="critical">` block from `commands/newTrack.md` Section 2.5 (lines 475-477) — the global directive now covers this
+- [ ] Task: Conductor - User Manual Verification 'Global enforcement refactor' (Protocol in workflow.md)
+
+### Critical files
+- `templates/askuserquestion-patterns.md` — add global enforcement section
+- `commands/newTrack.md` — remove per-section enforcement note

--- a/conductor/tracks/enforce-askuserquestion-all-questions_20260322/plan.md
+++ b/conductor/tracks/enforce-askuserquestion-all-questions_20260322/plan.md
@@ -2,9 +2,9 @@
 
 ### Phase 1: Global enforcement refactor
 
-- [ ] Task 1.1: Add enforcement section to `templates/askuserquestion-patterns.md` — add a `## Mandatory Usage` section near the top (after the Key Rules section) with clear directive that AskUserQuestion is mandatory for all interactive prompts, no exceptions
-- [ ] Task 1.2: Remove the `<note type="critical">` block from `commands/newTrack.md` Section 2.5 (lines 475-477) — the global directive now covers this
-- [ ] Task: Conductor - User Manual Verification 'Global enforcement refactor' (Protocol in workflow.md)
+- [x] Task 1.1: Add enforcement section to `templates/askuserquestion-patterns.md` — add a `## Mandatory Usage` section near the top (after the Key Rules section) with clear directive that AskUserQuestion is mandatory for all interactive prompts, no exceptions
+- [x] Task 1.2: Remove the `<note type="critical">` block from `commands/newTrack.md` Section 2.5 (lines 475-477) — the global directive now covers this
+- [x] Task: Conductor - User Manual Verification 'Global enforcement refactor' (Protocol in workflow.md)
 
 ### Critical files
 - `templates/askuserquestion-patterns.md` — add global enforcement section

--- a/conductor/tracks/enforce-askuserquestion-all-questions_20260322/spec.md
+++ b/conductor/tracks/enforce-askuserquestion-all-questions_20260322/spec.md
@@ -1,0 +1,28 @@
+## Specification
+
+### Overview
+Add a global enforcement directive to `templates/askuserquestion-patterns.md` — the single source of truth for the AskUserQuestion protocol — mandating that all interactive questions across all Conductor commands MUST use the AskUserQuestion tool, with no plain text questions allowed. Remove the per-section enforcement note from `commands/newTrack.md` since it will be covered globally.
+
+### Background
+Currently, enforcement is inconsistent:
+- `commands/newTrack.md` Section 2.5 has a `<note type="critical">` enforcing AskUserQuestion for that one section
+- All other question points across all commands lack explicit enforcement
+- `templates/askuserquestion-patterns.md` is the shared reference for the AskUserQuestion protocol, referenced by all commands — the ideal place for a global enforcement rule
+
+### Functional Requirements
+1. **FR-1:** Add a prominent enforcement section to `templates/askuserquestion-patterns.md` stating: all interactive questions in any Conductor command MUST use the AskUserQuestion tool — no plain text questions, without exception.
+2. **FR-2:** Remove the per-section `<note type="critical">` from `commands/newTrack.md` Section 2.5 (line 475-477) since the global directive covers it.
+
+### Non-Functional Requirements
+- Single source of truth for the enforcement rule
+- No structural changes to command phases or logic in any command file
+
+### Acceptance Criteria
+- `templates/askuserquestion-patterns.md` contains a clear, prominent enforcement directive
+- No per-section AskUserQuestion enforcement notes remain in any command file
+- Existing command logic and flow remain unchanged across all commands
+
+### Out of Scope
+- Adding JSON examples or templates inline to commands
+- Changing the question flow or count in any command
+- Refactoring how commands reference the patterns template

--- a/templates/askuserquestion-patterns.md
+++ b/templates/askuserquestion-patterns.md
@@ -24,6 +24,14 @@
 
 ---
 
+## Mandatory Usage
+
+<note type="critical">
+All interactive questions in any Conductor command MUST use the AskUserQuestion tool. Do NOT ask plain text questions — every user-facing prompt must go through AskUserQuestion, without exception. This applies to all commands (newTrack, implement, setup, codeReview, etc.) and all question types (clarifications, approvals, confirmations, option selections).
+</note>
+
+---
+
 ## Key Rules
 
 1. **Header Constraint:** Maximum 12 characters (e.g., "Interaction", "Data", "Scope")


### PR DESCRIPTION
## Summary
- Added `## Mandatory Usage` section with `<note type="critical">` to `templates/askuserquestion-patterns.md` as the single source of truth for AskUserQuestion enforcement across all Conductor commands
- Removed per-section enforcement notes from `commands/newTrack.md` (Section 2.5 critical note and line 146 inline parenthetical)
- Created track `enforce-askuserquestion-all-questions_20260322` with spec, plan, and metadata

## Test plan
- [x] Verify `templates/askuserquestion-patterns.md` contains the Mandatory Usage enforcement section
- [x] Verify no inline AskUserQuestion enforcement notes remain in any command file
- [x] Run `/conductor:codeReview dev` — passed with no blocking issues