### PR TITLE
refactor: Enforce parallel execution in codeReview command

### DIFF
--- a/commands/codeReview.md
+++ b/commands/codeReview.md
@@ -79,15 +79,9 @@ Store `data.stats` for the report summary.
 
 ---
 
-## 3.0 EXECUTION STRATEGY
+## 3.0 PARALLEL EXECUTION
 
-### 3.1 Prompt User
-
-Ask via AskUserQuestion: "How would you like to run the analysis?"
-- "Parallel (Recommended)" — specialist agents simultaneously
-- "Sequential" — inline analysis
-
-### 3.2 Parallel Execution (Preferred)
+### 3.1 Run Analysis
 
 **Prepare agent input** from CLI response:
 
@@ -115,9 +109,9 @@ If `conductor/product-guidelines.md` exists, read and include documentation/nami
 
 Each returns structured JSON: `{ "findings": [...], "summary": { "high": N, "medium": N, "low": N } }`
 
-### 3.3 Sequential Execution (Fallback)
+### 3.2 Inline Fallback (Agent Failure Only)
 
-If user selects Sequential, or as fallback for failed agents, run analysis inline using the checklists below.
+When one or more agents fail, fall back to inline analysis for the failed dimension using the checklists below.
 
 **Code Quality Checklist:**
 - Code smells: functions >50 lines, nesting >3 levels, duplicate code, magic numbers, dead code
@@ -141,8 +135,8 @@ Record each finding with: severity, file, line, issue, recommendation.
 ## 4.0 ERROR HANDLING
 
 ### Agent Failures
-- **1 agent fails:** Note failure in report, fall back to inline analysis (Section 3.3) for that dimension
-- **2+ agents fail:** Switch to full sequential mode, announce: "Switching to sequential analysis."
+- **1 agent fails:** Note failure in report, fall back to inline analysis (Section 3.2) for that dimension
+- **2+ agents fail:** Fall back to inline analysis for all dimensions, announce: "Multiple agents failed. Running inline fallback analysis."
 - **Invalid output:** Treat as failure, fall back to inline
 
 | Failed Agent | Inline Fallback |
@@ -162,8 +156,7 @@ Record each finding with: severity, file, line, issue, recommendation.
 
 ### 5.1 Aggregate Findings
 
-**Parallel:** Parse JSON from each agent, merge `findings` arrays, sum severity counts.
-**Sequential:** Gather findings from inline analysis.
+Parse JSON from each agent, merge `findings` arrays, sum severity counts. For any dimension that used inline fallback, include those findings in the same structure.
 
 ### 5.2 Generate Report
 

--- a/conductor/tracks/codereview-always-run-parallel_20260329/decisions.md
+++ b/conductor/tracks/codereview-always-run-parallel_20260329/decisions.md
@@ -1,0 +1,43 @@
+# Decisions Log
+
+> Architecture Decision Records (ADRs) for this track. Each decision documents the context, choice made, and consequences.
+
+## About This File
+
+This file captures significant technical and architectural decisions made during implementation. Not every choice needs to be documented—only those that:
+
+- Involve tradeoffs between alternatives
+- Have long-term implications
+- Would benefit future maintainers understanding "why"
+- Deviate from common patterns or conventions
+
+## Decision Format
+
+Each decision follows the ADR format:
+
+```markdown
+### ADR-###: [Decision Title]
+
+**Date:** YYYY-MM-DD
+**Status:** Proposed | Accepted | Deprecated | Superseded
+
+#### Context
+[Facts and circumstances that led to this decision point]
+
+#### Decision
+[The choice that was made]
+
+#### Consequences
+[Both positive and negative outcomes of this decision]
+
+#### Alternatives Considered (Optional)
+[Other options evaluated with brief pros/cons]
+```
+
+---
+
+## Decisions
+
+<!-- Decisions are added below in chronological order -->
+
+_No decisions recorded yet._

--- a/conductor/tracks/codereview-always-run-parallel_20260329/index.md
+++ b/conductor/tracks/codereview-always-run-parallel_20260329/index.md
@@ -1,0 +1,10 @@
+# Track: codeReview must always run in parallel, remove the option of inline
+
+> Remove the parallel vs sequential user choice from codeReview, making parallel the only execution path.
+
+## Documents
+
+- [Specification](./spec.md) - Track requirements and acceptance criteria
+- [Implementation Plan](./plan.md) - Phased implementation tasks
+- [Decisions](./decisions.md) - Architecture Decision Records
+- [Metadata](./metadata.json) - Track status and configuration

--- a/conductor/tracks/codereview-always-run-parallel_20260329/metadata.json
+++ b/conductor/tracks/codereview-always-run-parallel_20260329/metadata.json
@@ -1,0 +1,8 @@
+{
+  "track_id": "codereview-always-run-parallel_20260329",
+  "type": "refactor",
+  "status": "pending",
+  "description": "codeReview must always run in parallel, remove the option of inline",
+  "created_at": "2026-03-29T00:00:00Z",
+  "updated_at": "2026-03-29T00:00:00Z"
+}

--- a/conductor/tracks/codereview-always-run-parallel_20260329/metadata.json
+++ b/conductor/tracks/codereview-always-run-parallel_20260329/metadata.json
@@ -1,8 +1,8 @@
 {
   "track_id": "codereview-always-run-parallel_20260329",
   "type": "refactor",
-  "status": "pending",
+  "status": "completed",
   "description": "codeReview must always run in parallel, remove the option of inline",
   "created_at": "2026-03-29T00:00:00Z",
-  "updated_at": "2026-03-29T00:00:00Z"
+  "updated_at": "2026-03-29T21:56:57.008105Z"
 }

--- a/conductor/tracks/codereview-always-run-parallel_20260329/plan.md
+++ b/conductor/tracks/codereview-always-run-parallel_20260329/plan.md
@@ -2,12 +2,12 @@
 
 ### Phase 1: Remove sequential option from codeReview.md
 
-- [ ] Task 1.1: Remove Section 3.1 (the AskUserQuestion prompt for parallel vs sequential)
-- [ ] Task 1.2: Update Section 3.2 — rename to main execution path, remove "(Preferred)" qualifier
-- [ ] Task 1.3: Update Section 3.3 — rename to "Inline Fallback (Agent Failure Only)", remove "If user selects Sequential" references, keep checklists as error-only fallback
-- [ ] Task 1.4: Update Section 4.0 — remove "Switch to full sequential mode" as a user-facing concept, keep as internal fallback only
-- [ ] Task 1.5: Verify `commands/implement.md` Section 3.7 is already consistent (no changes expected)
-- [ ] Task: Conductor - User Manual Verification 'Remove sequential option from codeReview.md' (Protocol in workflow.md)
+- [x] Task 1.1: Remove Section 3.1 (the AskUserQuestion prompt for parallel vs sequential)
+- [x] Task 1.2: Update Section 3.2 — rename to main execution path, remove "(Preferred)" qualifier
+- [x] Task 1.3: Update Section 3.3 — rename to "Inline Fallback (Agent Failure Only)", remove "If user selects Sequential" references, keep checklists as error-only fallback
+- [x] Task 1.4: Update Section 4.0 — remove "Switch to full sequential mode" as a user-facing concept, keep as internal fallback only
+- [x] Task 1.5: Verify `commands/implement.md` Section 3.7 is already consistent (no changes expected)
+- [x] Task: Conductor - User Manual Verification 'Remove sequential option from codeReview.md' (Protocol in workflow.md)
 
 ### Critical files
 - `commands/codeReview.md` — primary file being modified (Sections 3.0-4.0)

--- a/conductor/tracks/codereview-always-run-parallel_20260329/plan.md
+++ b/conductor/tracks/codereview-always-run-parallel_20260329/plan.md
@@ -1,0 +1,14 @@
+## Implementation Plan
+
+### Phase 1: Remove sequential option from codeReview.md
+
+- [ ] Task 1.1: Remove Section 3.1 (the AskUserQuestion prompt for parallel vs sequential)
+- [ ] Task 1.2: Update Section 3.2 — rename to main execution path, remove "(Preferred)" qualifier
+- [ ] Task 1.3: Update Section 3.3 — rename to "Inline Fallback (Agent Failure Only)", remove "If user selects Sequential" references, keep checklists as error-only fallback
+- [ ] Task 1.4: Update Section 4.0 — remove "Switch to full sequential mode" as a user-facing concept, keep as internal fallback only
+- [ ] Task 1.5: Verify `commands/implement.md` Section 3.7 is already consistent (no changes expected)
+- [ ] Task: Conductor - User Manual Verification 'Remove sequential option from codeReview.md' (Protocol in workflow.md)
+
+### Critical files
+- `commands/codeReview.md` — primary file being modified (Sections 3.0-4.0)
+- `commands/implement.md` — verify consistency only (Section 3.7.3)

--- a/conductor/tracks/codereview-always-run-parallel_20260329/spec.md
+++ b/conductor/tracks/codereview-always-run-parallel_20260329/spec.md
@@ -1,0 +1,29 @@
+## Specification
+
+### Overview
+Refactor `commands/codeReview.md` to remove the parallel vs. sequential user prompt (Section 3.1) and make parallel execution the only path. Sequential/inline analysis is retained solely as an internal fallback for agent failures.
+
+### Background
+Section 3.1 currently asks users to choose between "Parallel (Recommended)" and "Sequential" via AskUserQuestion. In practice, parallel is always preferred. The sequential option adds unnecessary friction and an inferior code path that shouldn't be a user choice.
+
+### Functional Requirements
+1. **FR-1:** Remove Section 3.1 (the AskUserQuestion prompt) — parallel execution starts immediately after diff generation
+2. **FR-2:** Rename Section 3.2 from "Parallel Execution (Preferred)" to the main execution path, remove "(Preferred)" qualifier
+3. **FR-3:** Rename Section 3.3 from "Sequential Execution (Fallback)" to "Inline Fallback (Agent Failure Only)" — make clear this is not a user choice
+4. **FR-4:** Update Section 4.0 error handling to remove references to "user selects Sequential"
+5. **FR-5:** Verify `commands/implement.md` Section 3.7.3 is already consistent (runs parallel by default)
+
+### Non-Functional Requirements
+- No structural changes to the report format or agent definitions
+- Keep inline checklists intact for error fallback use
+
+### Acceptance Criteria
+- No AskUserQuestion prompt for execution strategy exists in codeReview.md
+- Parallel execution is the sole execution path
+- Inline analysis remains available only as agent failure fallback
+- Error handling in Section 4.0 reflects the removal of user choice
+
+### Out of Scope
+- Changes to agent definitions
+- Changes to implement.md (already runs parallel)
+- Report format changes


### PR DESCRIPTION
## Summary
- Removed the AskUserQuestion prompt (Section 3.1) that asked users to choose between parallel and sequential analysis
- Parallel execution is now the only path — Section 3.0 renamed to "PARALLEL EXECUTION"
- Inline analysis retained solely as internal fallback for agent failures (Section 3.2 "Inline Fallback (Agent Failure Only)")
- Updated error handling (Section 4.0) and report aggregation (Section 5.1) to remove sequential references

## Test plan
- [x] Verify no AskUserQuestion prompt for execution strategy exists in codeReview.md
- [x] Verify inline checklists preserved as agent failure fallback
- [x] Verify implement.md Section 3.7 already consistent (no changes needed)