### PR TITLE
feat(codeReview): Add save review prompt to codeReview and deduplicate with implement

### DIFF
--- a/commands/codeReview.md
+++ b/commands/codeReview.md
@@ -4,6 +4,7 @@ description: Performs comprehensive code review of changes in the current branch
 argument-hint: "<base_branch> (e.g., master, develop, main)"
 allowed-tools:
   - Read
+  - Write
   - Bash
   - Glob
   - Grep
@@ -230,3 +231,45 @@ Parse JSON from each agent, merge `findings` arrays, sum severity counts. For an
 1. Display complete report to user
 2. If high severity issues: "Please address high severity items before merging."
 3. If no issues: "Code review passed. No blocking issues found."
+
+---
+
+## 6.0 SAVE REVIEW
+
+### 6.1 Detect Track Context
+
+1. Get current branch: `git branch --show-current`
+2. Scan `conductor/tracks/*/metadata.json` files for a track whose branch matches the current git branch (match track shortname against branch name)
+3. If a match is found, store `track_id` and `track_path`. Set `TRACK_DETECTED = true`.
+4. If no match found, set `TRACK_DETECTED = false`.
+
+### 6.2 Prompt User
+
+Ask via AskUserQuestion:
+
+**If `TRACK_DETECTED = true`:**
+- Header: "Save review"
+- Question: "Would you like to save this review?"
+- Options: "Save to track (Recommended)" / "Save to file" / "Skip"
+
+**If `TRACK_DETECTED = false`:**
+- Header: "Save review"
+- Question: "Would you like to save this review?"
+- Options: "Save to file" / "Skip"
+
+### 6.3 Execute Save
+
+**"Save to track":**
+1. Write the generated report to `conductor/tracks/<track_id>/review.md`
+2. Read the track's `index.md` and add a link to the review file: `- [Review](./review.md) — Code review report`
+3. Write the updated `index.md`
+4. Announce: "Review saved to `conductor/tracks/<track_id>/review.md`."
+
+**"Save to file":**
+1. Ensure `conductor/reviews/` directory exists (`mkdir -p conductor/reviews/`)
+2. Derive filename: `<branch_name>_<YYYY-MM-DD>.md` (replace `/` in branch name with `-`)
+3. Write the generated report to `conductor/reviews/<filename>`
+4. Announce: "Review saved to `conductor/reviews/<filename>`."
+
+**"Skip":**
+1. Announce: "Review not saved."

--- a/commands/implement.md
+++ b/commands/implement.md
@@ -274,57 +274,18 @@ Ask via AskUserQuestion: "All tasks complete. Run automated code review before f
 - Options: "Run code review (Recommended)" / "Skip"
 - If Skip: return to finalization.
 
-### 3.7.2 Generate Diff via CLI
+### 3.7.2 Invoke codeReview
 
-Execute a single call to generate the filtered diff:
-```bash
-python ${CLAUDE_PLUGIN_ROOT}/scripts/conductor_cli.py --json codereview filtered-diff --base <BASE_BRANCH> --exclude "conductor/tracks/*"
+If the user selects review, invoke the codeReview command via the Skill tool:
+```
+skill: "conductor:codeReview", args: "<BASE_BRANCH>"
 ```
 
-The response includes:
-- `data.stats` — files_changed, lines_added, lines_removed, truncated flag
-- `data.language_breakdown` — per-language file counts and line counts
-- `data.file_stats` — per-file breakdown with language detection
-- `data.diff_content` — the full diff (filtered, size-capped)
+The codeReview command handles all diff generation, parallel analysis, report generation, display, and save prompting (Section 6.0). No additional logic is needed here.
 
-**Uncommitted changes check:** If `git status --porcelain` shows changes, ask user:
-- "All changes" → use `--base <BASE_BRANCH>` (includes working tree)
-- "Committed only" → default three-dot diff
-- "Skip review" → return to finalization
+### 3.7.3 Return to Finalization
 
-**Empty diff handling:** If no reviewable product files changed, announce and proceed to finalization.
-
-### 3.7.3 Run Analysis (Parallel)
-
-Prepare agent input from the CLI response:
-```json
-{
-  "diff_content": "<data.diff_content>",
-  "file_list": ["<from data.file_stats[].file>"],
-  "project_context": {
-    "tech_stack": "<from conductor/tech-stack.md>",
-    "language_breakdown": "<from data.language_breakdown>",
-    "styleguide_path": "conductor/code_styleguides/<language>.md",
-    "product_guidelines_path": "conductor/product-guidelines.md"
-  }
-}
-```
-
-**Launch all three agents simultaneously** in a single message:
-- `subagent_type: "code-quality-analyzer"`
-- `subagent_type: "security-scanner"`
-- `subagent_type: "test-coverage-analyzer"`
-
-**Failures:** 1 agent fails → note in report, proceed with others. 2+ fail → skip review.
-
-### 3.7.4 Generate and Save Report
-
-1. Aggregate findings from all agents (merge `findings` arrays, sum severity counts)
-2. Generate report using the template from `codeReview.md` Section 7.2 (Summary table, Code Quality, Security, Test Coverage, Recommendations sections). Add `**Track:** <description>` to header.
-3. Save to `conductor/tracks/<track_id>/review.md`
-4. Update track `index.md` with link to review
-5. Display report: High severity → "⚠️ Review before merging." / No high → "✅ No blocking issues."
-6. Return to finalization (review is non-blocking)
+After codeReview completes, return to finalization. The review is non-blocking.
 
 ---
 

--- a/conductor/tracks/codereview-save-prompt-deduplicate_20260330/decisions.md
+++ b/conductor/tracks/codereview-save-prompt-deduplicate_20260330/decisions.md
@@ -1,0 +1,43 @@
+# Decisions Log
+
+> Architecture Decision Records (ADRs) for this track. Each decision documents the context, choice made, and consequences.
+
+## About This File
+
+This file captures significant technical and architectural decisions made during implementation. Not every choice needs to be documented—only those that:
+
+- Involve tradeoffs between alternatives
+- Have long-term implications
+- Would benefit future maintainers understanding "why"
+- Deviate from common patterns or conventions
+
+## Decision Format
+
+Each decision follows the ADR format:
+
+```markdown
+### ADR-###: [Decision Title]
+
+**Date:** YYYY-MM-DD
+**Status:** Proposed | Accepted | Deprecated | Superseded
+
+#### Context
+[Facts and circumstances that led to this decision point]
+
+#### Decision
+[The choice that was made]
+
+#### Consequences
+[Both positive and negative outcomes of this decision]
+
+#### Alternatives Considered (Optional)
+[Other options evaluated with brief pros/cons]
+```
+
+---
+
+## Decisions
+
+<!-- Decisions are added below in chronological order -->
+
+_No decisions recorded yet._

--- a/conductor/tracks/codereview-save-prompt-deduplicate_20260330/index.md
+++ b/conductor/tracks/codereview-save-prompt-deduplicate_20260330/index.md
@@ -1,0 +1,8 @@
+# Track: CodeReview save prompt — deduplicate with implement
+
+## Documents
+
+- [Specification](./spec.md) — Track requirements and acceptance criteria
+- [Implementation Plan](./plan.md) — Phased implementation tasks
+- [Decisions](./decisions.md) — Architecture Decision Records
+- [Metadata](./metadata.json) — Track status and configuration

--- a/conductor/tracks/codereview-save-prompt-deduplicate_20260330/metadata.json
+++ b/conductor/tracks/codereview-save-prompt-deduplicate_20260330/metadata.json
@@ -1,0 +1,8 @@
+{
+  "track_id": "codereview-save-prompt-deduplicate_20260330",
+  "type": "refactor",
+  "status": "pending",
+  "description": "CodeReview save prompt — deduplicate with implement",
+  "created_at": "2026-03-30T00:00:00Z",
+  "updated_at": "2026-03-30T00:00:00Z"
+}

--- a/conductor/tracks/codereview-save-prompt-deduplicate_20260330/metadata.json
+++ b/conductor/tracks/codereview-save-prompt-deduplicate_20260330/metadata.json
@@ -1,8 +1,8 @@
 {
   "track_id": "codereview-save-prompt-deduplicate_20260330",
   "type": "refactor",
-  "status": "pending",
+  "status": "in_progress",
   "description": "CodeReview save prompt — deduplicate with implement",
   "created_at": "2026-03-30T00:00:00Z",
-  "updated_at": "2026-03-30T00:00:00Z"
+  "updated_at": "2026-03-30T12:27:30.433709Z"
 }

--- a/conductor/tracks/codereview-save-prompt-deduplicate_20260330/metadata.json
+++ b/conductor/tracks/codereview-save-prompt-deduplicate_20260330/metadata.json
@@ -1,8 +1,8 @@
 {
   "track_id": "codereview-save-prompt-deduplicate_20260330",
   "type": "refactor",
-  "status": "in_progress",
+  "status": "completed",
   "description": "CodeReview save prompt — deduplicate with implement",
   "created_at": "2026-03-30T00:00:00Z",
-  "updated_at": "2026-03-30T12:27:30.433709Z"
+  "updated_at": "2026-03-30T12:36:25.605744Z"
 }

--- a/conductor/tracks/codereview-save-prompt-deduplicate_20260330/plan.md
+++ b/conductor/tracks/codereview-save-prompt-deduplicate_20260330/plan.md
@@ -14,9 +14,9 @@
 
 ## Phase 2: Replace implement.md Section 3.7
 
-- [x] Task 2.1: Replace Sections 3.7.1–3.7.4 in `commands/implement.md` with:
+- [x] Task 2.1: Replace Sections 3.7.1–3.7.4 in `commands/implement.md` with: [c8ca3a4]
   - [x] Sub-task 2.1.1: Keep the prompt asking "All tasks complete. Run automated code review before finalizing?" with options "Run code review (Recommended)" / "Skip"
   - [x] Sub-task 2.1.2: If user selects review: invoke `/conductor:codeReview` via the Skill tool (passing the base branch)
   - [x] Sub-task 2.1.3: After codeReview completes (which now includes save prompt): return to finalization
   - [x] Sub-task 2.1.4: Remove all inline diff generation (3.7.2), parallel agent launch (3.7.3), and report save (3.7.4) logic
-- [ ] Task 2.2: Conductor - User Manual Verification 'Phase 2' (Protocol in workflow.md)
+- [x] Task 2.2: Conductor - User Manual Verification 'Phase 2' (Protocol in workflow.md)

--- a/conductor/tracks/codereview-save-prompt-deduplicate_20260330/plan.md
+++ b/conductor/tracks/codereview-save-prompt-deduplicate_20260330/plan.md
@@ -1,0 +1,22 @@
+# Implementation Plan: CodeReview save prompt — deduplicate with implement
+
+## Phase 1: Add Save Section to codeReview.md
+
+- [ ] Task 1.1: Add Section 5.4 "Save Review" to `commands/codeReview.md`
+  - [ ] Sub-task 1.1.1: Add track detection — scan `conductor/tracks/*/metadata.json` to match current git branch to a registered track
+  - [ ] Sub-task 1.1.2: Add AskUserQuestion prompt:
+    - If track detected: "Save to track" / "Save to file" / "Skip"
+    - If no track: "Save to file" / "Skip"
+  - [ ] Sub-task 1.1.3: Save-to-track: write report to `conductor/tracks/<track_id>/review.md`, update track `index.md`
+  - [ ] Sub-task 1.1.4: Standalone save: ensure `conductor/reviews/` exists, write to `conductor/reviews/<branch_name>_<YYYY-MM-DD>.md`
+  - [ ] Sub-task 1.1.5: Skip: display "Review not saved." and end
+- [ ] Task 1.2: Conductor - User Manual Verification 'Phase 1' (Protocol in workflow.md)
+
+## Phase 2: Replace implement.md Section 3.7
+
+- [ ] Task 2.1: Replace Sections 3.7.1–3.7.4 in `commands/implement.md` with:
+  - [ ] Sub-task 2.1.1: Keep the prompt asking "All tasks complete. Run automated code review before finalizing?" with options "Run code review (Recommended)" / "Skip"
+  - [ ] Sub-task 2.1.2: If user selects review: invoke `/conductor:codeReview` via the Skill tool (passing the base branch)
+  - [ ] Sub-task 2.1.3: After codeReview completes (which now includes save prompt): return to finalization
+  - [ ] Sub-task 2.1.4: Remove all inline diff generation (3.7.2), parallel agent launch (3.7.3), and report save (3.7.4) logic
+- [ ] Task 2.2: Conductor - User Manual Verification 'Phase 2' (Protocol in workflow.md)

--- a/conductor/tracks/codereview-save-prompt-deduplicate_20260330/plan.md
+++ b/conductor/tracks/codereview-save-prompt-deduplicate_20260330/plan.md
@@ -2,7 +2,7 @@
 
 ## Phase 1: Add Save Section to codeReview.md
 
-- [x] Task 1.1: Add Section 5.4 "Save Review" to `commands/codeReview.md`
+- [x] Task 1.1: Add Section 5.4 "Save Review" to `commands/codeReview.md` [ba0e29a]
   - [x] Sub-task 1.1.1: Add track detection — scan `conductor/tracks/*/metadata.json` to match current git branch to a registered track
   - [x] Sub-task 1.1.2: Add AskUserQuestion prompt:
     - If track detected: "Save to track" / "Save to file" / "Skip"
@@ -10,13 +10,13 @@
   - [x] Sub-task 1.1.3: Save-to-track: write report to `conductor/tracks/<track_id>/review.md`, update track `index.md`
   - [x] Sub-task 1.1.4: Standalone save: ensure `conductor/reviews/` exists, write to `conductor/reviews/<branch_name>_<YYYY-MM-DD>.md`
   - [x] Sub-task 1.1.5: Skip: display "Review not saved." and end
-- [ ] Task 1.2: Conductor - User Manual Verification 'Phase 1' (Protocol in workflow.md)
+- [x] Task 1.2: Conductor - User Manual Verification 'Phase 1' (Protocol in workflow.md)
 
 ## Phase 2: Replace implement.md Section 3.7
 
-- [ ] Task 2.1: Replace Sections 3.7.1–3.7.4 in `commands/implement.md` with:
-  - [ ] Sub-task 2.1.1: Keep the prompt asking "All tasks complete. Run automated code review before finalizing?" with options "Run code review (Recommended)" / "Skip"
-  - [ ] Sub-task 2.1.2: If user selects review: invoke `/conductor:codeReview` via the Skill tool (passing the base branch)
-  - [ ] Sub-task 2.1.3: After codeReview completes (which now includes save prompt): return to finalization
-  - [ ] Sub-task 2.1.4: Remove all inline diff generation (3.7.2), parallel agent launch (3.7.3), and report save (3.7.4) logic
+- [x] Task 2.1: Replace Sections 3.7.1–3.7.4 in `commands/implement.md` with:
+  - [x] Sub-task 2.1.1: Keep the prompt asking "All tasks complete. Run automated code review before finalizing?" with options "Run code review (Recommended)" / "Skip"
+  - [x] Sub-task 2.1.2: If user selects review: invoke `/conductor:codeReview` via the Skill tool (passing the base branch)
+  - [x] Sub-task 2.1.3: After codeReview completes (which now includes save prompt): return to finalization
+  - [x] Sub-task 2.1.4: Remove all inline diff generation (3.7.2), parallel agent launch (3.7.3), and report save (3.7.4) logic
 - [ ] Task 2.2: Conductor - User Manual Verification 'Phase 2' (Protocol in workflow.md)

--- a/conductor/tracks/codereview-save-prompt-deduplicate_20260330/plan.md
+++ b/conductor/tracks/codereview-save-prompt-deduplicate_20260330/plan.md
@@ -2,14 +2,14 @@
 
 ## Phase 1: Add Save Section to codeReview.md
 
-- [ ] Task 1.1: Add Section 5.4 "Save Review" to `commands/codeReview.md`
-  - [ ] Sub-task 1.1.1: Add track detection — scan `conductor/tracks/*/metadata.json` to match current git branch to a registered track
-  - [ ] Sub-task 1.1.2: Add AskUserQuestion prompt:
+- [x] Task 1.1: Add Section 5.4 "Save Review" to `commands/codeReview.md`
+  - [x] Sub-task 1.1.1: Add track detection — scan `conductor/tracks/*/metadata.json` to match current git branch to a registered track
+  - [x] Sub-task 1.1.2: Add AskUserQuestion prompt:
     - If track detected: "Save to track" / "Save to file" / "Skip"
     - If no track: "Save to file" / "Skip"
-  - [ ] Sub-task 1.1.3: Save-to-track: write report to `conductor/tracks/<track_id>/review.md`, update track `index.md`
-  - [ ] Sub-task 1.1.4: Standalone save: ensure `conductor/reviews/` exists, write to `conductor/reviews/<branch_name>_<YYYY-MM-DD>.md`
-  - [ ] Sub-task 1.1.5: Skip: display "Review not saved." and end
+  - [x] Sub-task 1.1.3: Save-to-track: write report to `conductor/tracks/<track_id>/review.md`, update track `index.md`
+  - [x] Sub-task 1.1.4: Standalone save: ensure `conductor/reviews/` exists, write to `conductor/reviews/<branch_name>_<YYYY-MM-DD>.md`
+  - [x] Sub-task 1.1.5: Skip: display "Review not saved." and end
 - [ ] Task 1.2: Conductor - User Manual Verification 'Phase 1' (Protocol in workflow.md)
 
 ## Phase 2: Replace implement.md Section 3.7

--- a/conductor/tracks/codereview-save-prompt-deduplicate_20260330/spec.md
+++ b/conductor/tracks/codereview-save-prompt-deduplicate_20260330/spec.md
@@ -1,0 +1,40 @@
+# Specification: CodeReview save prompt — deduplicate with implement
+
+## Overview
+
+The `implement` command (Section 3.7) has its own inline code review flow that duplicates diff generation, agent launching, and report saving. The `codeReview` command has no save capability. This track:
+
+1. Adds a "Save Review" section to `codeReview.md` so users can persist the report (track-aware or standalone).
+2. Replaces `implement.md` Section 3.7 with a simple call to `/conductor:codeReview`, eliminating all duplicated logic. Since codeReview now includes the save prompt, implement gets it for free.
+
+## Background
+
+- **implement.md Section 3.7** (lines 267-327): Has its own diff generation, parallel agent launch, report generation, and save-to-track logic — all of which duplicates what `codeReview` already does (minus the save).
+- **codeReview.md Section 5.3** (lines 228-232): Displays report and ends. No save.
+
+## Functional Requirements
+
+1. **FR-1: Save Prompt in codeReview** — After displaying the report, add Section 5.4 that asks the user via `AskUserQuestion` whether to save the review.
+2. **FR-2: Track-Aware Save** — If a current track is detected (match current git branch to a registered track's metadata), save to `conductor/tracks/<track_id>/review.md` and update the track's `index.md`.
+3. **FR-3: Standalone Save** — If no track detected, save to `conductor/reviews/<branch_name>_<date>.md`.
+4. **FR-4: Skip Option** — User can decline saving.
+5. **FR-5: Replace implement Section 3.7** — Replace the entire inline review (Sections 3.7.1–3.7.4) with: prompt user to run review → if yes, call `/conductor:codeReview` → return to finalization.
+
+## Non-Functional Requirements
+
+- `AskUserQuestion` constraints: 2-4 options, max 12-char header.
+- Additive to codeReview sections 1.0–5.3 — no changes to report generation or display.
+
+## Acceptance Criteria
+
+- [ ] `codeReview` prompts to save after displaying the report
+- [ ] Track-aware save writes to `conductor/tracks/<track_id>/review.md` and updates `index.md`
+- [ ] Standalone save writes to `conductor/reviews/`
+- [ ] User can skip saving
+- [ ] `implement` Section 3.7 is replaced with a `/conductor:codeReview` invocation
+- [ ] No duplicated diff generation, agent launching, or report logic in implement
+
+## Out of Scope
+
+- Review diffing or versioning
+- Changing the report template format


### PR DESCRIPTION
## Summary

- Added Section 6.0 "Save Review" to `codeReview.md` with track-aware detection, AskUserQuestion save prompt, and save-to-track/file/skip options
- Replaced `implement.md` Section 3.7 inline code review (diff generation, parallel agents, report save) with a single `/conductor:codeReview` skill invocation, eliminating duplication

## Test plan

- [x] Run `/conductor:codeReview` standalone and verify save prompt appears after report
- [x] Run `/conductor:implement` to completion and verify it invokes `/conductor:codeReview` for the review step
- [x] Test "Save to track" option when on a track branch
- [x] Test "Save to file" option for standalone reviews
- [x] Test "Skip" option